### PR TITLE
[nemo-qml-plugin-calendar] Don't load all recurring incidences when n…

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -776,12 +776,14 @@ void CalendarWorker::loadData(const QList<CalendarData::Range> &ranges,
     foreach (const CalendarData::Range &range, ranges)
         mStorage->load(range.first, range.second.addDays(1)); // end date is not inclusive
 
-    // Note: omitting recurrence ids since loadRecurringIncidences() loads them anyway
     foreach (const QString &uid, uidList)
-        mStorage->load(uid);
+        mStorage->loadSeries(uid);
 
-    // Load all recurring incidences, we have no other way to detect if they occur within a range
-    mStorage->loadRecurringIncidences();
+    if (!ranges.isEmpty()) {
+        // Load all recurring incidences,
+        // we have no other way to detect if they occur within a range
+        mStorage->loadRecurringIncidences();
+    }
 
     if (reset)
         mSentEvents.clear();


### PR DESCRIPTION
…ot necessary.

When loading data in the worker thread for particular events only,
don't load all recurring incidences in case they may be in a range.

@pvuorela and @chriadam this is a micro optimisation for cases where we are interested in an event by its UID only and there is no range load. Actually, this is not happening at the moment in the calendar application because we always load incidences by range before being able to view them one by one and do an EventQuery on them.

But in that case (no range load and EventQuery by UID), there is no need to load all recurring incidences. It cost 1s on my device and make the UID for log viewing behave like a slow truck.

I think the added `if` does not complicate much the code and was even implicit in the comment that was already existing.

What do you think ? In the future migration, adding a field in the component table to know when a recurring event is finishing its recurrences would be nice ;-) It would allow real range loading.