### PR TITLE
Fix missing events from different tz in agenda model.

### DIFF
--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -809,7 +809,10 @@ void CalendarManager::dataLoadedSlot(const QList<CalendarData::Range> &ranges,
     mLoadedRanges = addRanges(mLoadedRanges, ranges);
     mLoadedQueries.append(instanceList);
     mEvents = mEvents.unite(events);
-    mEventOccurrences = mEventOccurrences.unite(occurrences);
+    // Use mEventOccurrences.insert(occurrences) from Qt5.15,
+    // .unite() is deprecated and broken, it is duplicating keys.
+    for (const CalendarData::EventOccurrence &eo: occurrences)
+        mEventOccurrences.insert(eo.getId(), eo);
     mEventOccurrenceForDates = mEventOccurrenceForDates.unite(dailyOccurrences);
     mLoadPending = false;
 

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -416,15 +416,14 @@ void CalendarManager::updateAgendaModel(CalendarAgendaModel *model)
                 qWarning() << "no event for occurrence";
                 continue;
             }
-            QDate start = model->startDate();
-            QDate end = model->endDate();
 
+            const QDateTime startDt(model->startDate()); // To be replaced later by start.startOfDay()
+            const QDateTime endDt(model->endDate()); // To be replaced later by start.startOfDay()
             // on all day events the end time is inclusive, otherwise not
-            if ((eo.startTime.date() < start
-                 && (eo.endTime.date() > start
-                     || (eo.endTime.date() == start && (event->allDay()
-                                                        || eo.endTime.time() > QTime(0, 0)))))
-                    || (eo.startTime.date() >= start && eo.startTime.date() <= end)) {
+            if ((eo.eventAllDay && eo.startTime.date() <= model->endDate()
+                 && eo.endTime.date() >= model->startDate())
+                || (!eo.eventAllDay && eo.startTime < endDt.addDays(1)
+                    && eo.endTime >= startDt)) {
                 filtered.append(new CalendarEventOccurrence(eo.eventUid, eo.recurrenceId,
                                                             eo.startTime, eo.endTime));
             }

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -759,12 +759,12 @@ CalendarWorker::dailyEventOccurrences(const QList<CalendarData::Range> &ranges,
         QDate start = range.first;
         while (start <= range.second) {
             foreach (const CalendarData::EventOccurrence &eo, occurrences) {
+                const QDateTime startDt(start); // To be replaced later by start.startOfDay()
                 // On all day events the end time is inclusive, otherwise not
-                if ((eo.startTime.date() < start
-                     && (eo.endTime.date() > start
-                         || (eo.endTime.date() == start && (eo.eventAllDay
-                                                            || eo.endTime.time() > QTime(0, 0)))))
-                    || eo.startTime.date() == start) {
+                if ((eo.eventAllDay && eo.startTime.date() <= start
+                     && eo.endTime.date() >= start)
+                    || (!eo.eventAllDay && eo.startTime < startDt.addDays(1)
+                        && eo.endTime >= startDt)) {
                     occurrenceHash[start].append(eo.getId());
                 }
             }

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,7 +1,8 @@
 TEMPLATE = subdirs
 SUBDIRS = \
     tst_calendarmanager \
-    tst_calendarevent
+    tst_calendarevent \
+    tst_calendaragendamodel
 
 tests_xml.path = /opt/tests/nemo-qml-plugins-qt5/calendar
 tests_xml.files = tests.xml

--- a/tests/tst_calendaragendamodel/tst_calendaragendamodel.cpp
+++ b/tests/tst_calendaragendamodel/tst_calendaragendamodel.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2021 Damien Caliste <dcaliste@free.fr>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+#include <QObject>
+#include <QSignalSpy>
+#include <QtTest>
+
+#include "calendaragendamodel.h"
+#include "calendareventmodification.h"
+
+#include "plugin.cpp"
+
+class tst_CalendarAgendaModel : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+
+    void testStartEndDate();
+    void testTimeZone();
+    void testAllDays();
+};
+
+void tst_CalendarAgendaModel::initTestCase()
+{
+    CalendarManager *manager = CalendarManager::instance();
+    QSignalSpy *ready = new QSignalSpy(manager, &CalendarManager::notebooksChanged);
+    QVERIFY(ready->wait());
+    
+    QSignalSpy *modified = new QSignalSpy(manager, &CalendarManager::storageModified);
+    CalendarEventModification *event1 = new CalendarEventModification;
+    event1->setDescription(QString::fromLatin1("event 1"));
+    event1->setStartTime(QDateTime(QDate(2021, 11, 18), QTime(13, 29)),
+                         Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    event1->setEndTime(QDateTime(QDate(2021, 11, 18), QTime(14, 29)),
+                       Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    event1->save();
+    QVERIFY(modified->wait());
+    CalendarEventModification *event2 = new CalendarEventModification;
+    event2->setDescription(QString::fromLatin1("event 2"));
+    event2->setStartTime(QDateTime(QDate(2021, 11, 19), QTime(14, 34)),
+                         Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    event2->setEndTime(QDateTime(QDate(2021, 11, 20), QTime(14, 34)),
+                       Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    event2->save();
+    QVERIFY(modified->wait());
+    CalendarEventModification *event3 = new CalendarEventModification;
+    event3->setDescription(QString::fromLatin1("event far away"));
+    event3->setStartTime(QDateTime(QDate(2021, 11, 11), QTime(3, 0)),
+                         Qt::TimeZone, "Asia/Ho_Chi_Minh");
+    event3->setEndTime(QDateTime(QDate(2021, 11, 11), QTime(4, 0)),
+                       Qt::TimeZone, "Asia/Ho_Chi_Minh");
+    event3->save();
+    QVERIFY(modified->wait());
+    CalendarEventModification *allDayEvent1 = new CalendarEventModification;
+    allDayEvent1->setDescription(QString::fromLatin1("all day event 1"));
+    allDayEvent1->setStartTime(QDateTime(QDate(2021, 10, 11), QTime(0, 0)),
+                               Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    allDayEvent1->setEndTime(QDateTime(QDate(2021, 10, 11), QTime(0, 0)),
+                             Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    allDayEvent1->setAllDay(true);
+    allDayEvent1->save();
+    QVERIFY(modified->wait());
+    CalendarEventModification *allDayEvent2 = new CalendarEventModification;
+    allDayEvent2->setDescription(QString::fromLatin1("all day event 2"));
+    allDayEvent2->setStartTime(QDateTime(QDate(2021, 10, 12), QTime(0, 0)),
+                               Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    allDayEvent2->setEndTime(QDateTime(QDate(2021, 10, 15), QTime(0, 0)),
+                             Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    allDayEvent2->setAllDay(true);
+    allDayEvent2->save();
+    QVERIFY(modified->wait());
+    CalendarEventModification *allDayEvent3 = new CalendarEventModification;
+    allDayEvent3->setDescription(QString::fromLatin1("all day event 3"));
+    allDayEvent3->setStartTime(QDateTime(QDate(2021, 10, 10), QTime(0, 0)),
+                               Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    allDayEvent3->setEndTime(QDateTime(QDate(2021, 10, 10), QTime(0, 0)),
+                             Qt::TimeZone, QTimeZone::systemTimeZoneId());
+    allDayEvent3->setAllDay(true);
+    allDayEvent3->save();
+    QVERIFY(modified->wait());
+}
+
+void tst_CalendarAgendaModel::testStartEndDate()
+{
+    CalendarAgendaModel *model = new CalendarAgendaModel;
+
+    QSignalSpy *updated = new QSignalSpy(model, &CalendarAgendaModel::updated);
+    model->setStartDate(QDate(2021, 11, 17));
+    model->setEndDate(QDate(2021, 11, 19));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 2);
+    CalendarEventOccurrence *occurrence1 = model->get(0, CalendarAgendaModel::OccurrenceObjectRole).value<CalendarEventOccurrence*>();
+    QCOMPARE(occurrence1->eventObject()->description(), QString::fromLatin1("event 1"));
+    CalendarEventOccurrence *occurrence2 = model->get(1, CalendarAgendaModel::OccurrenceObjectRole).value<CalendarEventOccurrence*>();
+    QCOMPARE(occurrence2->eventObject()->description(), QString::fromLatin1("event 2"));
+    model->setStartDate(QDate(2021, 11, 17));
+    model->setEndDate(QDate(2021, 11, 17));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 0);
+    model->setStartDate(QDate(2021, 11, 18));
+    model->setEndDate(QDate(2021, 11, 18));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 1);
+
+    delete updated;
+    delete model;
+}
+
+void tst_CalendarAgendaModel::testTimeZone()
+{
+    const QByteArray TZenv(qgetenv("TZ"));
+    qputenv("TZ", "Europe/Paris");
+    CalendarAgendaModel *model = new CalendarAgendaModel;
+
+    QSignalSpy *updated = new QSignalSpy(model, &CalendarAgendaModel::updated);
+    model->setStartDate(QDate(2021, 11, 10));
+    model->setEndDate(QDate(2021, 11, 10));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 1);
+    CalendarEventOccurrence *occurrence1 = model->get(0, CalendarAgendaModel::OccurrenceObjectRole).value<CalendarEventOccurrence*>();
+    QCOMPARE(occurrence1->eventObject()->description(), QString::fromLatin1("event far away"));
+    model->setStartDate(QDate(2021, 11, 9));
+    model->setEndDate(QDate(2021, 11, 10));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 1);
+
+    delete updated;
+    delete model;
+
+    if (TZenv.isEmpty()) {
+        qunsetenv("TZ");
+    } else {
+        qputenv("TZ", TZenv);
+    }
+}
+
+void tst_CalendarAgendaModel::testAllDays()
+{
+    CalendarAgendaModel *model = new CalendarAgendaModel;
+
+    QSignalSpy *updated = new QSignalSpy(model, &CalendarAgendaModel::updated);
+    model->setStartDate(QDate(2021, 10, 11));
+    model->setEndDate(QDate(2021, 10, 12));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 2);
+    CalendarEventOccurrence *occurrence1 = model->get(0, CalendarAgendaModel::OccurrenceObjectRole).value<CalendarEventOccurrence*>();
+    QCOMPARE(occurrence1->eventObject()->description(), QString::fromLatin1("all day event 1"));
+    CalendarEventOccurrence *occurrence2 = model->get(1, CalendarAgendaModel::OccurrenceObjectRole).value<CalendarEventOccurrence*>();
+    QCOMPARE(occurrence2->eventObject()->description(), QString::fromLatin1("all day event 2"));
+    model->setStartDate(QDate(2021, 10, 9));
+    model->setEndDate(QDate(2021, 10, 9));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 0);
+    model->setStartDate(QDate(2021, 10, 11));
+    model->setEndDate(QDate(2021, 10, 11));
+    QVERIFY(updated->wait());
+    QCOMPARE(model->count(), 1);
+
+    delete updated;
+    delete model;
+}
+
+#include "tst_calendaragendamodel.moc"
+QTEST_MAIN(tst_CalendarAgendaModel)

--- a/tests/tst_calendaragendamodel/tst_calendaragendamodel.pro
+++ b/tests/tst_calendaragendamodel/tst_calendaragendamodel.pro
@@ -1,0 +1,4 @@
+include(../common.pri)
+
+TARGET = tst_calendaragendamodel
+SOURCES += tst_calendaragendamodel.cpp


### PR DESCRIPTION
It's actually the same PR than #11 but I was working on it also based on a new test to ensure that we're not creating regressions, or at least trying to be confident not to !

The test is demonstrating the problem : an event hapenning on D day in Ho Chi Minh city at 3am should be in an AgendaModel featuring D-1 day if this agenda model is created in a Paris time zone.

Creating such test, I actually also found that the AgendaModel is broken for multi-day agendas ! (luckily we're using it only for single day ranges in the calendar application). The `QHash::unite()` has been found to be misleading because uniting a hash with another one that contains the same keys result in the first hash to contains several time the key. Which kind of defeat the initial purpose of a Hash instead of a MultiHash. In Qt5.15, they noticed it and added the `QHash::insert(QHash)` function. Waiting for Qt5.15, I'm proposing to replace the unite with a for loop on single element insertion.

@pvuorela , what do you think ? @dkotin11, sorry for your work on #11, I thought that you started on another bug based on your last comment at that time, when I started this.