### PR TITLE
[nemo-qml-plugin-calendar] Add a displayLabel per occurrence.

### DIFF
--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -49,6 +49,7 @@ struct EventOccurrence {
     QDateTime recurrenceId;
     QDateTime startTime;
     QDateTime endTime;
+    QString displayLabel;
     bool eventAllDay;
 
     QString getId() const

--- a/src/calendareventoccurrence.cpp
+++ b/src/calendareventoccurrence.cpp
@@ -42,7 +42,20 @@ CalendarEventOccurrence::CalendarEventOccurrence(const QString &eventUid,
                                                  const QDateTime &startTime,
                                                  const QDateTime &endTime,
                                                  QObject *parent)
-    : QObject(parent), mEventUid(eventUid), mRecurrenceId(recurrenceId), mStartTime(startTime), mEndTime(endTime)
+: QObject(parent), mEventUid(eventUid), mRecurrenceId(recurrenceId), mStartTime(startTime), mEndTime(endTime)
+{
+    connect(CalendarManager::instance(), SIGNAL(eventUidChanged(QString,QString)),
+            this, SLOT(eventUidChanged(QString,QString)));
+}
+
+CalendarEventOccurrence::CalendarEventOccurrence(const CalendarData::EventOccurrence &occurrence,
+                                                 QObject *parent)
+    : QObject(parent)
+    , mEventUid(occurrence.eventUid)
+    , mRecurrenceId(occurrence.recurrenceId)
+    , mStartTime(occurrence.startTime)
+    , mEndTime(occurrence.endTime)
+    , mDisplayLabel(occurrence.displayLabel)
 {
     connect(CalendarManager::instance(), SIGNAL(eventUidChanged(QString,QString)),
             this, SLOT(eventUidChanged(QString,QString)));
@@ -101,4 +114,14 @@ QDateTime CalendarEventOccurrence::endTimeInTz() const
 {
     const CalendarEvent *event = eventObject();
     return event ? toEventDateTime(mEndTime, event->endTimeSpec(), event->endTimeZone()) : mEndTime;
+}
+
+QString CalendarEventOccurrence::displayLabel() const
+{
+    if (mDisplayLabel.isEmpty()) {
+        const CalendarEvent *event = eventObject();
+        return event ? event->displayLabel() : QString();
+    } else {
+        return mDisplayLabel;
+    }
 }

--- a/src/calendareventoccurrence.h
+++ b/src/calendareventoccurrence.h
@@ -36,6 +36,8 @@
 #include <QObject>
 #include <QDateTime>
 
+#include "calendardata.h"
+
 class CalendarEvent;
 
 class CalendarEventOccurrence : public QObject
@@ -47,6 +49,7 @@ class CalendarEventOccurrence : public QObject
     // startTimeInTz and endTimeInTz are given in event startTime / endTime timezone
     Q_PROPERTY(QDateTime startTimeInTz READ startTimeInTz CONSTANT)
     Q_PROPERTY(QDateTime endTimeInTz READ endTimeInTz CONSTANT)
+    Q_PROPERTY(QString displayLabel READ displayLabel CONSTANT)
     Q_PROPERTY(CalendarEvent *event READ eventObject CONSTANT)
 
 public:
@@ -55,12 +58,15 @@ public:
                             const QDateTime &startTime,
                             const QDateTime &endTime,
                             QObject *parent = 0);
+    CalendarEventOccurrence(const CalendarData::EventOccurrence &occurrence,
+                            QObject *parent = 0);
     ~CalendarEventOccurrence();
 
     QDateTime startTime() const;
     QDateTime endTime() const;
     QDateTime startTimeInTz() const;
     QDateTime endTimeInTz() const;
+    QString displayLabel() const;
     CalendarEvent *eventObject() const;
 
 private slots:
@@ -71,6 +77,7 @@ private:
     QDateTime mRecurrenceId;
     QDateTime mStartTime;
     QDateTime mEndTime;
+    QString mDisplayLabel;
 };
 
 #endif // CALENDAREVENTOCCURRENCE_H

--- a/src/calendarimportevent.cpp
+++ b/src/calendarimportevent.cpp
@@ -202,9 +202,5 @@ QObject *CalendarImportEvent::nextOccurrence()
     if (!mEvent)
         return 0;
 
-    CalendarData::EventOccurrence eo = CalendarUtils::getNextOccurrence(mEvent);
-    return new CalendarEventOccurrence(eo.eventUid,
-                                       eo.recurrenceId,
-                                       eo.startTime,
-                                       eo.endTime);
+    return new CalendarEventOccurrence(CalendarUtils::getNextOccurrence(mEvent));
 }

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -402,9 +402,7 @@ void CalendarManager::updateAgendaModel(CalendarAgendaModel *model)
     if (model->startDate() == model->endDate() || !model->endDate().isValid()) {
         foreach (const QString &id, mEventOccurrenceForDates.value(model->startDate())) {
             if (mEventOccurrences.contains(id)) {
-                CalendarData::EventOccurrence eo = mEventOccurrences.value(id);
-                filtered.append(new CalendarEventOccurrence(eo.eventUid, eo.recurrenceId,
-                                                            eo.startTime, eo.endTime));
+                filtered.append(new CalendarEventOccurrence(mEventOccurrences.value(id)));
             } else {
                 qWarning() << "no occurrence with id" << id;
             }
@@ -425,8 +423,7 @@ void CalendarManager::updateAgendaModel(CalendarAgendaModel *model)
                      || (eo.endTime.date() == start && (event->allDay()
                                                         || eo.endTime.time() > QTime(0, 0)))))
                     || (eo.startTime.date() >= start && eo.startTime.date() <= end)) {
-                filtered.append(new CalendarEventOccurrence(eo.eventUid, eo.recurrenceId,
-                                                            eo.startTime, eo.endTime));
+                filtered.append(new CalendarEventOccurrence(eo));
             }
         }
     }
@@ -759,7 +756,7 @@ CalendarEventOccurrence* CalendarManager::getNextOccurrence(const QString &uid, 
         return new CalendarEventOccurrence(QString(), QDateTime(), QDateTime(), QDateTime());
     }
 
-    return new CalendarEventOccurrence(eo.eventUid, eo.recurrenceId, eo.startTime, eo.endTime);
+    return new CalendarEventOccurrence(eo);
 }
 
 QList<CalendarData::Attendee> CalendarManager::getEventAttendees(const QString &uid, const QDateTime &recurrenceId, bool *resultValid)

--- a/src/calendarutils.cpp
+++ b/src/calendarutils.cpp
@@ -244,7 +244,8 @@ QList<QObject *> CalendarUtils::convertAttendeeList(const QList<CalendarData::At
 }
 
 CalendarData::EventOccurrence CalendarUtils::getNextOccurrence(const KCalendarCore::Event::Ptr &event,
-                                                               const QDateTime &start)
+                                                               const QDateTime &start,
+                                                               const QString &notebookId)
 {
     const QTimeZone systemTimeZone = QTimeZone::systemTimeZone();
 
@@ -276,6 +277,10 @@ CalendarData::EventOccurrence CalendarUtils::getNextOccurrence(const KCalendarCo
         occurrence.startTime = dtStart;
         occurrence.endTime = dtEnd;
         occurrence.eventAllDay = event->allDay();
+        // This UID is hard-coded in contactsd/plugin/birthday/cdbirthdaycalendar.cpp
+        if (notebookId == QString::fromLatin1("b1376da7-5555-1111-2222-227549c4e570")) {
+            occurrence.displayLabel = QString::fromLatin1("%1 (%2)").arg(event->summary()).arg(event->dtStart().daysTo(dtStart) / 365);
+        }
     }
 
     return occurrence;

--- a/src/calendarutils.h
+++ b/src/calendarutils.h
@@ -52,7 +52,8 @@ QDateTime getReminderDateTime(const KCalendarCore::Event::Ptr &event);
 QList<CalendarData::Attendee> getEventAttendees(const KCalendarCore::Event::Ptr &event);
 QList<QObject*> convertAttendeeList(const QList<CalendarData::Attendee> &list);
 CalendarData::EventOccurrence getNextOccurrence(const KCalendarCore::Event::Ptr &event,
-                                                const QDateTime &start = QDateTime::currentDateTime());
+                                                const QDateTime &start = QDateTime::currentDateTime(),
+                                                const QString &notebookId = QString());
 bool importFromFile(const QString &fileName, KCalendarCore::Calendar::Ptr calendar);
 bool importFromIcsRawData(const QByteArray &icsData, KCalendarCore::Calendar::Ptr calendar);
 CalendarEvent::Response convertPartStat(KCalendarCore::Attendee::PartStat status);

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -742,6 +742,11 @@ CalendarWorker::eventOccurrences(const QList<CalendarData::Range> &ranges) const
                 occurrence.startTime = sdt;
                 occurrence.endTime = elapsed.end(sdt);
                 occurrence.eventAllDay = it.incidence()->allDay();
+                // This UID is hard-coded in contactsd/plugin/birthday/cdbirthdaycalendar.cpp
+                if (mNotebooks.value(mCalendar->notebook(it.incidence())).uid
+                    == QString::fromLatin1("b1376da7-5555-1111-2222-227549c4e570")) {
+                    occurrence.displayLabel = QString::fromLatin1("%1 (%2)").arg(it.incidence()->summary()).arg(it.incidence()->dtStart().daysTo(sdt) / 365);
+                }
                 filtered.insert(occurrence.getId(), occurrence);
             }
         }
@@ -1029,7 +1034,7 @@ CalendarData::EventOccurrence CalendarWorker::getNextOccurrence(const QString &u
                                                                 const QDateTime &start) const
 {
     KCalendarCore::Event::Ptr event = mCalendar->event(uid, recurrenceId);
-    return CalendarUtils::getNextOccurrence(event, start);
+    return CalendarUtils::getNextOccurrence(event, start, mCalendar->notebook(event));
 }
 
 QList<CalendarData::Attendee> CalendarWorker::getEventAttendees(const QString &uid, const QDateTime &recurrenceId)


### PR DESCRIPTION
Having a displayLabel per occurrence allows to adjust it for
recurring events like birthdays. So the label can change
with the occurrence and display the age for instance.

@chriadam and @pvuorela , after thinking a lot how to implement an age display for the birthdays, I concluded that it must be done at the occurrence level. It's the object that is changing for a given event (like a day of birth) at every iteration. By overloading the displayLabel (or the description) of the occurrences, one can implement a display of the age at the given day.

Now, there are still some ugly bits :
* we overload the displayLabel depending on the notebook uid, so it is done only for the internal birthday calendar.
* there are two place where the code is duplicated at the moment. I need to clean this.
* I want to avoid as much as possible to introduce translatable strings in the middleware, so the age is given in parenthesis, besides the name, which is nice or not.

Of course, there are one or two places in the Jolla calendar application where there should be a `s/event ? event.displayLabel : ""/occurrence ? occurrence.displayLabel : ""/`. The PR is not done at the moment. I would like to discuss the approach here to the problem first.