### PR TITLE
[nemo-qml-plugin-calendar] Expose identifier in event list model.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -1,7 +1,7 @@
 Name:       nemo-qml-plugin-calendar-qt5
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.6.19
+Version:    0.6.27
 Release:    1
 License:    BSD
 URL:        https://git.sailfishos.org/mer-core/nemo-qml-plugin-calendar

--- a/src/calendareventlistmodel.cpp
+++ b/src/calendareventlistmodel.cpp
@@ -57,6 +57,7 @@ QHash<int, QByteArray> CalendarEventListModel::roleNames() const
     QHash<int,QByteArray> roleNames;
     roleNames[EventObjectRole] = "event";
     roleNames[OccurrenceObjectRole] = "occurrence";
+    roleNames[IdentifierRole] = "identifier";
     return roleNames;
 }
 
@@ -111,6 +112,7 @@ void CalendarEventListModel::doRefresh()
     beginResetModel();
     qDeleteAll(mEvents);
     mEvents.clear();
+    mEventIdentifiers.clear();
     mMissingItems.clear();
 
     for (const QString &id : mIdentifiers) {
@@ -118,6 +120,7 @@ void CalendarEventListModel::doRefresh()
         CalendarData::Event event = CalendarManager::instance()->getEvent(id, &loaded);
         if (event.isValid()) {
             mEvents.append(new CalendarEventOccurrence(event.uniqueId, event.recurrenceId, event.startTime, event.endTime, this));
+            mEventIdentifiers.append(id);
         } else if (loaded) {
             mMissingItems.append(id);
         }
@@ -141,9 +144,10 @@ QVariant CalendarEventListModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case EventObjectRole:
         return QVariant::fromValue<QObject *>(mEvents.at(index.row())->eventObject());
-    case OccurrenceObjectRole: {
+    case OccurrenceObjectRole:
         return QVariant::fromValue<QObject *>(mEvents.at(index.row()));
-    }
+    case IdentifierRole:
+        return QVariant::fromValue<QString>(mEventIdentifiers.at(index.row()));
     default:
         qWarning() << "CalendarEventListModel: Unknown role asked";
         return QVariant();

--- a/src/calendareventlistmodel.h
+++ b/src/calendareventlistmodel.h
@@ -48,7 +48,8 @@ class CalendarEventListModel : public QAbstractListModel, public QQmlParserStatu
 public:
     enum EventListRoles {
         EventObjectRole = Qt::UserRole,
-        OccurrenceObjectRole
+        OccurrenceObjectRole,
+        IdentifierRole
     };
     Q_ENUM(EventListRoles)
 
@@ -86,6 +87,7 @@ private:
     QStringList mIdentifiers;
     QStringList mMissingItems;
     QList<CalendarEventOccurrence*> mEvents;
+    QStringList mEventIdentifiers; // contains a subset of mIdentifiers corresponding to events in mEvents
 };
 
 #endif // CALENDAREVENTLISTMODEL_H


### PR DESCRIPTION
Modify a bit the event list model, so the identifiers that are the input of the model are also expose as data for each row in the model.

@chriadam , you can see the use for it in https://github.com/dcaliste/harbour/logbook