### PR TITLE
[nemo-qml-plugin-calendar] Expose the sync failure resolution in even…

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -1,7 +1,7 @@
 Name:       nemo-qml-plugin-calendar-qt5
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.6.32
+Version:    0.6.34
 Release:    1
 License:    BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-calendar

--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -79,6 +79,7 @@ struct Event {
     CalendarEvent::Response ownerStatus = CalendarEvent::ResponseUnspecified;
     CalendarEvent::Status status = CalendarEvent::StatusNone;
     CalendarEvent::SyncFailure syncFailure = CalendarEvent::NoSyncFailure;
+    CalendarEvent::SyncFailureResolution syncFailureResolution = CalendarEvent::RetrySync;
 
     bool operator==(const Event& other) const
     {

--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -182,6 +182,11 @@ CalendarEvent::SyncFailure CalendarEvent::syncFailure() const
     return mManager->getEvent(mUniqueId, mRecurrenceId).syncFailure;
 }
 
+CalendarEvent::SyncFailureResolution CalendarEvent::syncFailureResolution() const
+{
+    return mManager->getEvent(mUniqueId, mRecurrenceId).syncFailureResolution;
+}
+
 CalendarEvent::Response CalendarEvent::ownerStatus() const
 {
     return mManager->getEvent(mUniqueId, mRecurrenceId).ownerStatus;

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -69,6 +69,7 @@ class CalendarEvent : public QObject
     Q_PROPERTY(CalendarEvent::Secrecy secrecy READ secrecy NOTIFY secrecyChanged)
     Q_PROPERTY(CalendarEvent::Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(CalendarEvent::SyncFailure syncFailure READ syncFailure NOTIFY syncFailureChanged)
+    Q_PROPERTY(CalendarEvent::SyncFailureResolution syncFailureResolution READ syncFailureResolution NOTIFY syncFailureResolutionChanged)
     Q_PROPERTY(CalendarEvent::Response ownerStatus READ ownerStatus NOTIFY ownerStatusChanged)
     Q_PROPERTY(bool rsvp READ rsvp NOTIFY rsvpChanged)
     Q_PROPERTY(bool externalInvitation READ externalInvitation NOTIFY externalInvitationChanged)
@@ -116,11 +117,20 @@ public:
 
     enum SyncFailure {
         NoSyncFailure,
+        CreationFailure,
         UploadFailure,
         UpdateFailure,
         DeleteFailure
     };
     Q_ENUM(SyncFailure)
+
+    enum SyncFailureResolution {
+        RetrySync,
+        KeepOutOfSync,
+        PushDeviceData,
+        PullServerData
+    };
+    Q_ENUM(SyncFailureResolution)
 
     enum Status {
         StatusNone,
@@ -158,6 +168,7 @@ public:
     Secrecy secrecy() const;
     Status status() const;
     SyncFailure syncFailure() const;
+    SyncFailureResolution syncFailureResolution() const;
     Response ownerStatus() const;
     bool rsvp() const;
     bool externalInvitation() const;
@@ -189,6 +200,7 @@ signals:
     void secrecyChanged();
     void statusChanged();
     void syncFailureChanged();
+    void syncFailureResolutionChanged();
     void ownerStatusChanged();
     void rsvpChanged();
     void externalInvitationChanged();

--- a/src/calendareventmodification.cpp
+++ b/src/calendareventmodification.cpp
@@ -289,3 +289,17 @@ CalendarEventModification::replaceOccurrence(CalendarEventOccurrence *occurrence
     return CalendarManager::instance()->replaceOccurrence(m_event, occurrence, m_attendeesSet,
                                                           m_requiredAttendees, m_optionalAttendees);
 }
+
+CalendarEvent::SyncFailureResolution CalendarEventModification::syncFailureResolution() const
+{
+    return m_event.syncFailureResolution;
+}
+
+void CalendarEventModification::setSyncFailureResolution(CalendarEvent::SyncFailureResolution resolution)
+{
+    if (m_event.syncFailureResolution != resolution) {
+        m_event.syncFailureResolution = resolution;
+        emit syncFailureResolutionChanged();
+    }
+}
+

--- a/src/calendareventmodification.h
+++ b/src/calendareventmodification.h
@@ -58,6 +58,7 @@ class CalendarEventModification : public QObject
     Q_PROPERTY(QDateTime reminderDateTime READ reminderDateTime WRITE setReminderDateTime NOTIFY reminderDateTimeChanged)
     Q_PROPERTY(QString location READ location WRITE setLocation NOTIFY locationChanged)
     Q_PROPERTY(QString calendarUid READ calendarUid WRITE setCalendarUid NOTIFY calendarUidChanged)
+    Q_PROPERTY(CalendarEvent::SyncFailureResolution syncFailureResolution READ syncFailureResolution WRITE setSyncFailureResolution NOTIFY syncFailureResolutionChanged)
 
 public:
     CalendarEventModification(CalendarData::Event data, QObject *parent = 0);
@@ -104,6 +105,9 @@ public:
     QString calendarUid() const;
     void setCalendarUid(const QString &uid);
 
+    CalendarEvent::SyncFailureResolution syncFailureResolution() const;
+    void setSyncFailureResolution(CalendarEvent::SyncFailureResolution resolution);
+
     Q_INVOKABLE void setAttendees(CalendarContactModel *required, CalendarContactModel *optional);
 
     Q_INVOKABLE void save();
@@ -123,6 +127,7 @@ signals:
     void recurEndDateChanged();
     void hasRecurEndDateChanged();
     void calendarUidChanged();
+    void syncFailureResolutionChanged();
 
 private:
     CalendarData::Event m_event;

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -306,6 +306,18 @@ void CalendarWorker::setEventData(KCalendarCore::Event::Ptr &event, const Calend
             event->recurrence()->setDuration(-1);
         }
     }
+
+    if (eventData.syncFailureResolution == CalendarEvent::RetrySync) {
+        event->removeCustomProperty("VOLATILE", "SYNC-FAILURE-RESOLUTION");
+    } else if (eventData.syncFailureResolution == CalendarEvent::KeepOutOfSync) {
+        event->setCustomProperty("VOLATILE", "SYNC-FAILURE-RESOLUTION", "keep-out-of-sync");
+    } else if (eventData.syncFailureResolution == CalendarEvent::PushDeviceData) {
+        event->setCustomProperty("VOLATILE", "SYNC-FAILURE-RESOLUTION", "device-reset");
+    } else if (eventData.syncFailureResolution == CalendarEvent::PullServerData) {
+        event->setCustomProperty("VOLATILE", "SYNC-FAILURE-RESOLUTION", "server-reset");
+    } else {
+        qWarning() << "No support for sync failure resolution" << eventData.syncFailureResolution;
+    }
 }
 
 void CalendarWorker::replaceOccurrence(const CalendarData::Event &eventData, const QDateTime &startTime,
@@ -894,10 +906,22 @@ CalendarData::Event CalendarWorker::createEventStruct(const KCalendarCore::Event
     const QString &syncFailure = e->customProperty("VOLATILE", "SYNC-FAILURE");
     if (syncFailure.compare("upload", Qt::CaseInsensitive) == 0) {
         event.syncFailure = CalendarEvent::UploadFailure;
+    } else if (syncFailure.compare("upload-new", Qt::CaseInsensitive) == 0) {
+        event.syncFailure = CalendarEvent::CreationFailure;
     } else if (syncFailure.compare("update", Qt::CaseInsensitive) == 0) {
         event.syncFailure = CalendarEvent::UpdateFailure;
     } else if (syncFailure.compare("delete", Qt::CaseInsensitive) == 0) {
         event.syncFailure = CalendarEvent::DeleteFailure;
+    }
+    const QString &syncResolution = e->customProperty("VOLATILE", "SYNC-FAILURE-RESOLUTION");
+    if (syncResolution.compare("keep-out-of-sync", Qt::CaseInsensitive) == 0) {
+        event.syncFailureResolution = CalendarEvent::KeepOutOfSync;
+    } else if (syncResolution.compare("server-reset", Qt::CaseInsensitive) == 0) {
+        event.syncFailureResolution = CalendarEvent::PullServerData;
+    } else if (syncResolution.compare("device-reset", Qt::CaseInsensitive) == 0) {
+        event.syncFailureResolution = CalendarEvent::PushDeviceData;
+    } else if (!syncResolution.isEmpty()) {
+        qWarning() << "unsupported sync failure resolution" << syncResolution;
     }
     bool externalInvitation = false;
     const QString &calendarOwnerEmail = getNotebookAddress(e);


### PR DESCRIPTION
…t and event modification.

This is the UI part of sailfishos/buteo-sync-plugin-caldav#10 to add flags on failing events to avoid to retry them on each sync, if the user decides that it's hopeless.

Currently, we have two actions :
* retry on next sync (default, no flag),
* keep out of sync (ignore the event during the delta calculation for sync).