### PR TITLE
[nemo-qml-plugin-calendar] Expose the event status to QML.

### DIFF
--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -77,6 +77,7 @@ struct Event {
     CalendarEvent::Secrecy secrecy;
     QString calendarUid;
     CalendarEvent::Response ownerStatus = CalendarEvent::ResponseUnspecified;
+    CalendarEvent::Status status = CalendarEvent::StatusNone;
     CalendarEvent::SyncFailure syncFailure = CalendarEvent::NoSyncFailure;
 
     bool operator==(const Event& other) const

--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -172,6 +172,11 @@ CalendarEvent::Secrecy CalendarEvent::secrecy() const
     return mManager->getEvent(mUniqueId, mRecurrenceId).secrecy;
 }
 
+CalendarEvent::Status CalendarEvent::status() const
+{
+    return mManager->getEvent(mUniqueId, mRecurrenceId).status;
+}
+
 CalendarEvent::SyncFailure CalendarEvent::syncFailure() const
 {
     return mManager->getEvent(mUniqueId, mRecurrenceId).syncFailure;

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -67,6 +67,7 @@ class CalendarEvent : public QObject
     Q_PROPERTY(QString calendarUid READ calendarUid NOTIFY calendarUidChanged)
     Q_PROPERTY(QString location READ location NOTIFY locationChanged)
     Q_PROPERTY(CalendarEvent::Secrecy secrecy READ secrecy NOTIFY secrecyChanged)
+    Q_PROPERTY(CalendarEvent::Status status READ status NOTIFY statusChanged)
     Q_PROPERTY(CalendarEvent::SyncFailure syncFailure READ syncFailure NOTIFY syncFailureChanged)
     Q_PROPERTY(CalendarEvent::Response ownerStatus READ ownerStatus NOTIFY ownerStatusChanged)
     Q_PROPERTY(bool rsvp READ rsvp NOTIFY rsvpChanged)
@@ -121,6 +122,14 @@ public:
     };
     Q_ENUM(SyncFailure)
 
+    enum Status {
+        StatusNone,
+        StatusTentative,
+        StatusConfirmed,
+        StatusCancelled
+    };
+    Q_ENUM(Status)
+
     CalendarEvent(CalendarManager *manager, const QString &uid, const QDateTime &recurrenceId);
     ~CalendarEvent();
 
@@ -147,6 +156,7 @@ public:
     QDateTime recurrenceId() const;
     QString recurrenceIdString() const;
     Secrecy secrecy() const;
+    Status status() const;
     SyncFailure syncFailure() const;
     Response ownerStatus() const;
     bool rsvp() const;
@@ -177,6 +187,7 @@ signals:
     void hasRecurEndDateChanged();
     void recurWeeklyDaysChanged();
     void secrecyChanged();
+    void statusChanged();
     void syncFailureChanged();
     void ownerStatusChanged();
     void rsvpChanged();

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -862,6 +862,9 @@ void CalendarManager::sendEventChangeSignals(const CalendarData::Event &newEvent
     if (newEvent.secrecy != oldEvent.secrecy)
         emit eventObject->secrecyChanged();
 
+    if (newEvent.status != oldEvent.status)
+        emit eventObject->statusChanged();
+
     if (newEvent.recur != oldEvent.recur)
         emit eventObject->recurChanged();
 

--- a/src/calendarutils.cpp
+++ b/src/calendarutils.cpp
@@ -132,6 +132,21 @@ CalendarEvent::Secrecy CalendarUtils::convertSecrecy(const KCalendarCore::Event:
     }
 }
 
+CalendarEvent::Status CalendarUtils::convertStatus(const KCalendarCore::Event::Ptr &event)
+{
+    switch (event->status()) {
+    case KCalendarCore::Incidence::StatusTentative:
+        return CalendarEvent::StatusTentative;
+    case KCalendarCore::Incidence::StatusConfirmed:
+        return CalendarEvent::StatusConfirmed;
+    case KCalendarCore::Incidence::StatusCanceled:
+        return CalendarEvent::StatusCancelled;
+    case KCalendarCore::Incidence::StatusNone:
+    default:
+        return CalendarEvent::StatusNone;
+    }
+}
+
 int CalendarUtils::getReminder(const KCalendarCore::Event::Ptr &event)
 {
     KCalendarCore::Alarm::List alarms = event->alarms();

--- a/src/calendarutils.h
+++ b/src/calendarutils.h
@@ -47,6 +47,7 @@ namespace CalendarUtils {
 CalendarEvent::Recur convertRecurrence(const KCalendarCore::Event::Ptr &event);
 CalendarEvent::Days convertDayPositions(const KCalendarCore::Event::Ptr &event);
 CalendarEvent::Secrecy convertSecrecy(const KCalendarCore::Event::Ptr &event);
+CalendarEvent::Status convertStatus(const KCalendarCore::Event::Ptr &event);
 int getReminder(const KCalendarCore::Event::Ptr &event);
 QDateTime getReminderDateTime(const KCalendarCore::Event::Ptr &event);
 QList<CalendarData::Attendee> getEventAttendees(const KCalendarCore::Event::Ptr &event);

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -296,6 +296,7 @@ void CalendarWorker::setEventData(KCalendarCore::Event::Ptr &event, const Calend
     event->setLocation(eventData.location);
     setReminder(event, eventData.reminder, eventData.reminderDateTime);
     setRecurrence(event, eventData.recur, eventData.recurWeeklyDays);
+    setStatus(event, eventData.status);
 
     if (eventData.recur != CalendarEvent::RecurOnce) {
         event->recurrence()->setEndDate(eventData.recurEndDate);
@@ -461,6 +462,30 @@ bool CalendarWorker::setReminder(KCalendarCore::Event::Ptr &event, int seconds, 
     }
 
     return true;
+}
+
+bool CalendarWorker::setStatus(KCalendarCore::Event::Ptr &event, CalendarEvent::Status status)
+{
+    if (!event)
+        return false;
+
+    switch (status) {
+    case CalendarEvent::StatusNone:
+        event->setStatus(KCalendarCore::Incidence::StatusNone);
+        return true;
+    case CalendarEvent::StatusTentative:
+        event->setStatus(KCalendarCore::Incidence::StatusTentative);
+        return true;
+    case CalendarEvent::StatusConfirmed:
+        event->setStatus(KCalendarCore::Incidence::StatusConfirmed);
+        return true;
+    case CalendarEvent::StatusCancelled:
+        event->setStatus(KCalendarCore::Incidence::StatusCanceled);
+        return true;
+    default:
+        qWarning() << "unknown status value" << status;
+    }
+    return false;
 }
 
 bool CalendarWorker::needSendCancellation(KCalendarCore::Event::Ptr &event) const
@@ -865,6 +890,7 @@ CalendarData::Event CalendarWorker::createEventStruct(const KCalendarCore::Event
     event.readOnly = mStorage->notebook(event.calendarUid)->isReadOnly();
     event.recur = CalendarUtils::convertRecurrence(e);
     event.recurWeeklyDays = CalendarUtils::convertDayPositions(e);
+    event.status = CalendarUtils::convertStatus(e);
     const QString &syncFailure = e->customProperty("VOLATILE", "SYNC-FAILURE");
     if (syncFailure.compare("upload", Qt::CaseInsensitive) == 0) {
         event.syncFailure = CalendarEvent::UploadFailure;

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -120,6 +120,7 @@ private:
 
     bool setRecurrence(KCalendarCore::Event::Ptr &event, CalendarEvent::Recur recur, CalendarEvent::Days days);
     bool setReminder(KCalendarCore::Event::Ptr &event, int seconds, const QDateTime &dateTime);
+    bool setStatus(KCalendarCore::Event::Ptr &event, CalendarEvent::Status status);
     bool needSendCancellation(KCalendarCore::Event::Ptr &event) const;
     void updateEventAttendees(KCalendarCore::Event::Ptr event, bool newEvent,
                               const QList<CalendarData::EmailContact> &required,


### PR DESCRIPTION
It is exposing the STATUS property to QML, but it requires a patch in KCalendarCore that is not yet there, since KCalendarCore is currently hiding cancelled occurrences of recurring events.

It can be tested with plain cancelled events though.