### PR TITLE
[nemo-qml-plugin-calendar] Compare also time spec when assigning star…

### DIFF
--- a/src/calendareventmodification.cpp
+++ b/src/calendareventmodification.cpp
@@ -108,7 +108,10 @@ void CalendarEventModification::setStartTime(const QDateTime &startTime, Qt::Tim
 {
     QDateTime newStartTimeInTz = startTime;
     updateTime(&newStartTimeInTz, spec, timezone);
-    if (m_event.startTime != newStartTimeInTz) {
+    if (m_event.startTime != newStartTimeInTz
+        || m_event.startTime.timeSpec() != newStartTimeInTz.timeSpec()
+        || (m_event.startTime.timeSpec() == Qt::TimeZone
+            && m_event.startTime.timeZone() != newStartTimeInTz.timeZone())) {
         m_event.startTime = newStartTimeInTz;
         emit startTimeChanged();
     }
@@ -123,7 +126,10 @@ void CalendarEventModification::setEndTime(const QDateTime &endTime, Qt::TimeSpe
 {
     QDateTime newEndTimeInTz = endTime;
     updateTime(&newEndTimeInTz, spec, timezone);
-    if (m_event.endTime != newEndTimeInTz) {
+    if (m_event.endTime != newEndTimeInTz
+        || m_event.endTime.timeSpec() != newEndTimeInTz.timeSpec()
+        || (m_event.endTime.timeSpec() == Qt::TimeZone
+            && m_event.endTime.timeZone() != newEndTimeInTz.timeZone())) {
         m_event.endTime = newEndTimeInTz;
         emit endTimeChanged();
     }


### PR DESCRIPTION
…t or end times.

The QDateTime::operator== used to check if start or end time of
an event modification has been changed is comparing points in time
while one may be interested to change the time spec (from a time
zone one to a floating one), resolving locally to the same point
in time.

Reproducer:
- create an event with a given start date time in the system time zone (default),
- modify the event, keep the time, but change to local time (no time zone).
(@pvuorela, actually, if you look at the event modification page again, it is still stored with the system time zone, but that's an issue with mKCal, to see that the proper spec is passed to mKCal, add a debug message in the worker thread displaying `dtStart` for the saved event in `::saveEvent()`)

It's funny that KCalendarCore guys were bitten by the same bug one month ago, see https://invent.kde.org/frameworks/kcalendarcore/-/commit/9f4628aa2c6c90c94fd36d2d4ac8e940adc93680 So to see the fix working here, you also need to use the latest 5.90 version of KCalendarCore.

The fix is not taking into account cases where one would actually change the time zone and the time itself, so the old and the new point to the same point in time… Do you think it's worth to add it, or it's overly complicating things ?