### PR TITLE
[nemo-qml-plugin-calendar] Save EXDATE in localtime only if the event…

### DIFF
--- a/src/calendarutils.h
+++ b/src/calendarutils.h
@@ -53,7 +53,8 @@ QDateTime getReminderDateTime(const KCalendarCore::Event::Ptr &event);
 QList<CalendarData::Attendee> getEventAttendees(const KCalendarCore::Event::Ptr &event);
 QList<QObject*> convertAttendeeList(const QList<CalendarData::Attendee> &list);
 CalendarData::EventOccurrence getNextOccurrence(const KCalendarCore::Event::Ptr &event,
-                                                const QDateTime &start = QDateTime::currentDateTime());
+                                                const QDateTime &start = QDateTime::currentDateTime(),
+                                                const KCalendarCore::Incidence::List &exceptions = KCalendarCore::Incidence::List());
 bool importFromFile(const QString &fileName, KCalendarCore::Calendar::Ptr calendar);
 bool importFromIcsRawData(const QByteArray &icsData, KCalendarCore::Calendar::Ptr calendar);
 CalendarEvent::Response convertPartStat(KCalendarCore::Attendee::PartStat status);

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -131,7 +131,10 @@ void CalendarWorker::deleteEvent(const QString &uid, const QDateTime &recurrence
         // We're deleting an occurrence from a recurring event.
         // No incidence is deleted from the database in that case,
         // only the base incidence is modified by adding an exDate.
-        event->recurrence()->addExDateTime(dateTime);
+        if (dateTime.timeSpec() == Qt::LocalTime && event->dtStart().timeSpec() != Qt::LocalTime)
+            event->recurrence()->addExDateTime(dateTime.toTimeZone(event->dtStart().timeZone()));
+        else
+            event->recurrence()->addExDateTime(dateTime);
         event->setRevision(event->revision() + 1);
     } else {
         mCalendar->deleteEvent(event);

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -1059,7 +1059,15 @@ CalendarData::EventOccurrence CalendarWorker::getNextOccurrence(const QString &u
                                                                 const QDateTime &start) const
 {
     KCalendarCore::Event::Ptr event = mCalendar->event(uid, recurrenceId);
-    return CalendarUtils::getNextOccurrence(event, start);
+    if (!event) {
+        qWarning() << "Failed to get next occurrence, event not found. UID = " << uid << recurrenceId;
+        return CalendarData::EventOccurrence();
+    }
+    if (event->recurs() && !mStorage->loadSeries(uid)) {
+        qWarning() << "Failed to load series of event. UID = " << uid << recurrenceId;
+        return CalendarData::EventOccurrence();
+    }
+    return CalendarUtils::getNextOccurrence(event, start, event->recurs() ? mCalendar->instances(event) : KCalendarCore::Incidence::List());
 }
 
 QList<CalendarData::Attendee> CalendarWorker::getEventAttendees(const QString &uid, const QDateTime &recurrenceId)

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -224,8 +224,8 @@ void tst_CalendarEvent::testSave()
 
     QCOMPARE(eventB->endTime().timeSpec(), Qt::LocalTime);
     QCOMPARE(eventB->startTime().timeSpec(), Qt::LocalTime);
-    QCOMPARE(eventB->endTimeSpec(), Qt::TimeZone);
-    QCOMPARE(eventB->startTimeSpec(), Qt::TimeZone);
+    QCOMPARE(eventB->endTimeSpec(), endTime.timeSpec());
+    QCOMPARE(eventB->startTimeSpec(), startTime.timeSpec());
     QCOMPARE(eventB->endTimeZone().toUtf8(), endTime.timeZone().id());
     QCOMPARE(eventB->startTimeZone().toUtf8(), startTime.timeZone().id());
 
@@ -299,12 +299,9 @@ void tst_CalendarEvent::testTimeZone()
 
     QCOMPARE(eventB->endTime().timeSpec(), Qt::LocalTime);
     QCOMPARE(eventB->startTime().timeSpec(), Qt::LocalTime);
-    if (spec == Qt::UTC) {
-        QCOMPARE(eventB->endTimeSpec(), spec);
-        QCOMPARE(eventB->startTimeSpec(), spec);
-    } else {
-        QCOMPARE(eventB->endTimeSpec(), Qt::TimeZone);
-        QCOMPARE(eventB->startTimeSpec(), Qt::TimeZone);
+    QCOMPARE(eventB->endTimeSpec(), spec);
+    QCOMPARE(eventB->startTimeSpec(), spec);
+    if (spec != Qt::UTC) {
         QCOMPARE(eventB->endTimeZone().toUtf8(), endTime.timeZone().id());
         QCOMPARE(eventB->startTimeZone().toUtf8(), startTime.timeZone().id());
     }


### PR DESCRIPTION
… is in localtime.

@pvuorela, this is a follow-up of sailfishos/mkcal#13 that introduced a "strange" behaviour. Indeed, QDateTime coming from QML are always in `Qt::LocalTime`, so now they are stored as that and not converted to the system time zone. So when deleting an occurrence of a recurring event, an EXDATE is added as `EXDATE:20220215T0900` while the event is given with a time zone. So the exdate is taken into effect only if the device is in the right time zone. Changing time zone makes the deleted occurrence appearing again. And further more, while being RFC valid, this is confusing some caldav servers (openexchange for instance) if there are exdates in local time and exdates with a time zone.

I'm proposing to enforce EXDATE in the same spec or time zone than the DTSTART.
Since it's RFC valid to mix local time and time zone, I didn't enforce this at mKCal level, but prefer to do it here.