### PR TITLE
[nemo-qml-plugin-calendar] Fix calendarmanager test. JB#57290

### DIFF
--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -2,9 +2,15 @@
 <testdefinition version="1.0">
   <suite name="nemo-qml-plugins-calendar-qt5-tests" domain="mw">
     <set name="unit-tests" feature="calendar mw">
-       <case manual="false" name="calendarmanager">
-         <step>SQLITESTORAGEDB=/tmp/testdb /usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins-qt5/calendar/tst_calendarmanager</step>
-       </case>
-     </set>
+      <case manual="false" name="calendarmanager">
+        <step>rm -f /tmp/testdb; SQLITESTORAGEDB=/tmp/testdb /usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins-qt5/calendar/tst_calendarmanager</step>
+      </case>
+      <case manual="false" name="calendarevent">
+        <step>rm -f /tmp/testdb; SQLITESTORAGEDB=/tmp/testdb /usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins-qt5/calendar/tst_calendarevent</step>
+      </case>
+      <case manual="false" name="calendaragendamodel">
+        <step>rm -f /tmp/testdb; SQLITESTORAGEDB=/tmp/testdb /usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/nemo-qml-plugins-qt5/calendar/tst_calendaragendamodel</step>
+      </case>
+    </set>
   </suite>
 </testdefinition>


### PR DESCRIPTION
Bunch of things were going wrong here:

- The test was creating its own instance of CalendarManager to test,
used in the range test, but then the api test used the singleton
instance -> two calendar manager instances running at the same time,
other being deleted before the direct mkcal instances. Confusion.

Now just creating a new instance for each test, making the tests mess up
less with each other.

- Notebook api test failing got the test crashing if it hadn't yet
instantiated mStorage. Added null protection

- Notebook api is adjusting the default notebook on and off, but
at the same time expecting the test is started with a default notebook
set. Thus based on luck the test started failing if executed on an
existing database. Removed the signal spy on loading and now checking
only the signals on explicit actions.

@Tomin1 @llewelld @dcaliste 