### PR TITLE
[nemo-qml-plugin-calendar] Factorise code between classes sharing eve…

### DIFF
--- a/lightweight/calendardataservice/calendardataservice.cpp
+++ b/lightweight/calendardataservice/calendardataservice.cpp
@@ -90,8 +90,8 @@ void CalendarDataService::updated()
     for (int i = 0; i < mAgendaModel->count(); i++) {
         QVariant variant = mAgendaModel->get(i, CalendarAgendaModel::EventObjectRole);
         QVariant occurrenceVariant = mAgendaModel->get(i, CalendarAgendaModel::OccurrenceObjectRole);
-        if (variant.canConvert<CalendarEvent *>() && occurrenceVariant.canConvert<CalendarEventOccurrence *>()) {
-            CalendarEvent* event = variant.value<CalendarEvent *>();
+        if (variant.canConvert<CalendarStoredEvent *>() && occurrenceVariant.canConvert<CalendarEventOccurrence *>()) {
+            CalendarStoredEvent* event = variant.value<CalendarStoredEvent *>();
             CalendarEventOccurrence* occurrence = occurrenceVariant.value<CalendarEventOccurrence *>();
             EventData eventStruct;
             eventStruct.displayLabel = event->displayLabel();

--- a/src/calendarapi.cpp
+++ b/src/calendarapi.cpp
@@ -51,16 +51,9 @@ CalendarEventModification *CalendarApi::createNewEvent()
     return new CalendarEventModification();
 }
 
-CalendarEventModification * CalendarApi::createModification(CalendarEvent *sourceEvent)
+CalendarEventModification * CalendarApi::createModification(CalendarStoredEvent *sourceEvent)
 {
-    if (sourceEvent) {
-        CalendarData::Event data = CalendarManager::instance()->getEvent(sourceEvent->uniqueId(),
-                                                                         sourceEvent->recurrenceId());
-        return new CalendarEventModification(data);
-    } else {
-        qWarning("Null event passed to Calendar.getModification(). Returning new event.");
-        return createNewEvent();
-    }
+    return new CalendarEventModification(sourceEvent);
 }
 
 void CalendarApi::remove(const QString &uid, const QString &recurrenceId, const QDateTime &time)

--- a/src/calendarapi.h
+++ b/src/calendarapi.h
@@ -39,7 +39,7 @@
 
 class QJSEngine;
 class QQmlEngine;
-class CalendarEvent;
+class CalendarStoredEvent;
 class CalendarEventModification;
 
 class CalendarApi : public QObject
@@ -52,7 +52,7 @@ public:
     CalendarApi(QObject *parent = 0);
 
     Q_INVOKABLE CalendarEventModification *createNewEvent();
-    Q_INVOKABLE CalendarEventModification *createModification(CalendarEvent *sourceEvent);
+    Q_INVOKABLE CalendarEventModification *createModification(CalendarStoredEvent *sourceEvent);
 
     Q_INVOKABLE void remove(const QString &uid, const QString &recurrenceId = QString(),
                             const QDateTime &time = QDateTime());

--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -38,7 +38,7 @@
 #include <QDateTime>
 
 // KCalendarCore
-#include <KCalendarCore/Attendee>
+#include <KCalendarCore/Event>
 
 #include "calendarevent.h"
 
@@ -66,20 +66,25 @@ struct Event {
     bool readOnly = false;
     bool rsvp = false;
     bool externalInvitation = false;
-    CalendarEvent::Recur recur;
+    CalendarEvent::Recur recur = CalendarEvent::RecurOnce;
     QDate recurEndDate;
     CalendarEvent::Days recurWeeklyDays;
-    int reminder; // seconds; 15 minutes before event = +900, at time of event = 0, no reminder = negative value.
+    int reminder = -1; // seconds; 15 minutes before event = +900, at time of event = 0, no reminder = negative value.
     QDateTime reminderDateTime; // Valid when reminder is at a given date and time.
     QString uniqueId;
     QDateTime recurrenceId;
     QString location;
-    CalendarEvent::Secrecy secrecy;
+    CalendarEvent::Secrecy secrecy = CalendarEvent::SecrecyPublic;
     QString calendarUid;
     CalendarEvent::Response ownerStatus = CalendarEvent::ResponseUnspecified;
     CalendarEvent::Status status = CalendarEvent::StatusNone;
     CalendarEvent::SyncFailure syncFailure = CalendarEvent::NoSyncFailure;
     CalendarEvent::SyncFailureResolution syncFailureResolution = CalendarEvent::RetrySync;
+
+    Event() {}
+    Event(const KCalendarCore::Event &event);
+
+    void toKCalendarCore(KCalendarCore::Event::Ptr &event) const;
 
     bool operator==(const Event& other) const
     {
@@ -90,6 +95,14 @@ struct Event {
     {
         return !uniqueId.isEmpty();
     }
+
+private:
+    int fromKReminder(const KCalendarCore::Event &event) const;
+    QDateTime fromKReminderDateTime(const KCalendarCore::Event &event) const;
+    void toKReminder(KCalendarCore::Event &event) const;
+    CalendarEvent::Days fromKDayPositions(const KCalendarCore::Event &event) const;
+    CalendarEvent::Recur fromKRecurrence(const KCalendarCore::Event &event) const;
+    void toKRecurrence(KCalendarCore::Event &event) const;
 };
 
 struct Notebook {

--- a/src/calendareventmodification.h
+++ b/src/calendareventmodification.h
@@ -41,19 +41,16 @@
 #include "calendarchangeinformation.h"
 #include "calendarcontactmodel.h"
 
-class CalendarEventModification : public QObject
+class CalendarEventModification : public CalendarEvent
 {
     Q_OBJECT
+    // These properties already exist in the CalendarEvent class, but are redefined
+    // here to add WRITE access.
     Q_PROPERTY(QString displayLabel READ displayLabel WRITE setDisplayLabel NOTIFY displayLabelChanged)
     Q_PROPERTY(QString description READ description WRITE setDescription NOTIFY descriptionChanged)
-    Q_PROPERTY(QDateTime startTime READ startTime NOTIFY startTimeChanged)
-    Q_PROPERTY(QDateTime endTime READ endTime NOTIFY endTimeChanged)
     Q_PROPERTY(bool allDay READ allDay WRITE setAllDay NOTIFY allDayChanged)
     Q_PROPERTY(CalendarEvent::Recur recur READ recur WRITE setRecur NOTIFY recurChanged)
-    Q_PROPERTY(QDateTime recurEndDate READ recurEndDate NOTIFY recurEndDateChanged)
     Q_PROPERTY(CalendarEvent::Days recurWeeklyDays READ recurWeeklyDays WRITE setRecurWeeklyDays NOTIFY recurWeeklyDaysChanged)
-    Q_PROPERTY(bool hasRecurEndDate READ hasRecurEndDate NOTIFY hasRecurEndDateChanged)
-    Q_PROPERTY(QString recurrenceId READ recurrenceIdString CONSTANT)
     Q_PROPERTY(int reminder READ reminder WRITE setReminder NOTIFY reminderChanged)
     Q_PROPERTY(QDateTime reminderDateTime READ reminderDateTime WRITE setReminderDateTime NOTIFY reminderDateTimeChanged)
     Q_PROPERTY(QString location READ location WRITE setLocation NOTIFY locationChanged)
@@ -61,14 +58,12 @@ class CalendarEventModification : public QObject
     Q_PROPERTY(CalendarEvent::SyncFailureResolution syncFailureResolution READ syncFailureResolution WRITE setSyncFailureResolution NOTIFY syncFailureResolutionChanged)
 
 public:
-    CalendarEventModification(CalendarData::Event data, QObject *parent = 0);
+    CalendarEventModification(const CalendarStoredEvent *source, QObject *parent = 0);
     explicit CalendarEventModification(QObject *parent = 0);
     ~CalendarEventModification();
 
-    QString displayLabel() const;
     void setDisplayLabel(const QString &displayLabel);
 
-    QString description() const;
     void setDescription(const QString &description);
 
     QDateTime startTime() const;
@@ -77,32 +72,21 @@ public:
     QDateTime endTime() const;
     Q_INVOKABLE void setEndTime(const QDateTime &endTime, Qt::TimeSpec spec, const QString &timezone = QString());
 
-    bool allDay() const;
     void setAllDay(bool);
 
-    CalendarEvent::Recur recur() const;
     void setRecur(CalendarEvent::Recur);
 
-    QDateTime recurEndDate() const;
-    bool hasRecurEndDate() const;
     Q_INVOKABLE void setRecurEndDate(const QDateTime &dateTime);
     Q_INVOKABLE void unsetRecurEndDate();
 
-    CalendarEvent::Days recurWeeklyDays() const;
     void setRecurWeeklyDays(CalendarEvent::Days days);
 
-    QString recurrenceIdString() const;
-
-    int reminder() const;
     void setReminder(int seconds);
 
-    QDateTime reminderDateTime() const;
     void setReminderDateTime(const QDateTime &dateTime);
 
-    QString location() const;
     void setLocation(const QString &newLocation);
 
-    QString calendarUid() const;
     void setCalendarUid(const QString &uid);
 
     CalendarEvent::SyncFailureResolution syncFailureResolution() const;
@@ -130,8 +114,7 @@ signals:
     void syncFailureResolutionChanged();
 
 private:
-    CalendarData::Event m_event;
-    bool m_attendeesSet;
+    bool m_attendeesSet = false;
     QList<CalendarData::EmailContact> m_requiredAttendees;
     QList<CalendarData::EmailContact> m_optionalAttendees;
 };

--- a/src/calendareventoccurrence.cpp
+++ b/src/calendareventoccurrence.cpp
@@ -62,7 +62,7 @@ QDateTime CalendarEventOccurrence::endTime() const
     return mEndTime;
 }
 
-CalendarEvent *CalendarEventOccurrence::eventObject() const
+CalendarStoredEvent *CalendarEventOccurrence::eventObject() const
 {
     return CalendarManager::instance()->eventObject(mEventUid, mRecurrenceId);
 }

--- a/src/calendareventoccurrence.h
+++ b/src/calendareventoccurrence.h
@@ -36,7 +36,7 @@
 #include <QObject>
 #include <QDateTime>
 
-class CalendarEvent;
+class CalendarStoredEvent;
 
 class CalendarEventOccurrence : public QObject
 {
@@ -47,7 +47,7 @@ class CalendarEventOccurrence : public QObject
     // startTimeInTz and endTimeInTz are given in event startTime / endTime timezone
     Q_PROPERTY(QDateTime startTimeInTz READ startTimeInTz CONSTANT)
     Q_PROPERTY(QDateTime endTimeInTz READ endTimeInTz CONSTANT)
-    Q_PROPERTY(CalendarEvent *event READ eventObject CONSTANT)
+    Q_PROPERTY(CalendarStoredEvent *event READ eventObject CONSTANT)
 
 public:
     CalendarEventOccurrence(const QString &eventUid,
@@ -61,7 +61,7 @@ public:
     QDateTime endTime() const;
     QDateTime startTimeInTz() const;
     QDateTime endTimeInTz() const;
-    CalendarEvent *eventObject() const;
+    CalendarStoredEvent *eventObject() const;
 
 private slots:
     void eventUidChanged(QString oldUid, QString newUid);

--- a/src/calendarimportevent.h
+++ b/src/calendarimportevent.h
@@ -38,52 +38,25 @@
 // KCalendarCore
 #include <KCalendarCore/Event>
 
+#include "calendardata.h"
 #include "calendarevent.h"
 
-class CalendarImportEvent : public QObject
+class CalendarImportEvent : public CalendarEvent
 {
     Q_OBJECT
-    Q_PROPERTY(QString displayLabel READ displayLabel CONSTANT)
-    Q_PROPERTY(QString description READ description CONSTANT)
-    Q_PROPERTY(QDateTime startTime READ startTime CONSTANT)
-    Q_PROPERTY(QDateTime endTime READ endTime CONSTANT)
-    Q_PROPERTY(bool allDay READ allDay CONSTANT)
-    Q_PROPERTY(CalendarEvent::Recur recur READ recur CONSTANT)
-    Q_PROPERTY(CalendarEvent::Days recurWeeklyDays READ recurWeeklyDays CONSTANT)
-    Q_PROPERTY(int reminder READ reminder CONSTANT)
-    Q_PROPERTY(QDateTime reminderDateTime READ reminderDateTime CONSTANT)
-    Q_PROPERTY(QString uniqueId READ uniqueId CONSTANT)
     Q_PROPERTY(QString color READ color WRITE setColor NOTIFY colorChanged)
-    Q_PROPERTY(QString location READ location CONSTANT)
     Q_PROPERTY(QList<QObject*> attendees READ attendees CONSTANT)
     Q_PROPERTY(QString organizer READ organizer CONSTANT)
     Q_PROPERTY(QString organizerEmail READ organizerEmail CONSTANT)
-    Q_PROPERTY(CalendarEvent::Secrecy secrecy READ secrecy CONSTANT)
-    Q_PROPERTY(CalendarEvent::Response ownerStatus READ ownerStatus CONSTANT)
-    Q_PROPERTY(bool rsvp READ rsvp CONSTANT)
-    Q_PROPERTY(bool readOnly READ readOnly CONSTANT)
 
 public:
-    CalendarImportEvent(KCalendarCore::Event::Ptr event);
+    CalendarImportEvent(const KCalendarCore::Event::Ptr &event);
 
-    QString displayLabel() const;
-    QString description() const;
-    QDateTime startTime() const;
-    QDateTime endTime() const;
-    bool allDay() const;
-    CalendarEvent::Recur recur();
-    CalendarEvent::Days recurWeeklyDays();
-    int reminder() const;
-    QDateTime reminderDateTime() const;
-    QString uniqueId() const;
-    QString color() const;
-    bool readOnly() const;
-    QString location() const;
     QList<QObject*> attendees() const;
-    CalendarEvent::Secrecy secrecy() const;
     QString organizer() const;
     QString organizerEmail() const;
 
+    QString color() const;
     void setColor(const QString &color);
 
     CalendarEvent::Response ownerStatus() const;
@@ -98,7 +71,10 @@ signals:
     void colorChanged();
 
 private:
-    KCalendarCore::Event::Ptr mEvent;
     QString mColor;
+    QString mOrganizer;
+    QString mOrganizerEmail;
+    QList<CalendarData::Attendee> mAttendees;
+    CalendarData::EventOccurrence mOccurrence;
 };
 #endif // CALENDARIMPORTEVENT_H

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -61,7 +61,7 @@ public:
     static CalendarManager *instance(bool createIfNeeded = true);
     ~CalendarManager();
 
-    CalendarEvent* eventObject(const QString &eventUid, const QDateTime &recurrenceId);
+    CalendarStoredEvent* eventObject(const QString &eventUid, const QDateTime &recurrenceId);
 
     void saveModification(CalendarData::Event eventData, bool updateAttendees,
                           const QList<CalendarData::EmailContact> &required,
@@ -152,13 +152,12 @@ private:
     QList<CalendarData::Range> addRanges(const QList<CalendarData::Range> &oldRanges,
                                          const QList<CalendarData::Range> &newRanges);
     void updateAgendaModel(CalendarAgendaModel *model);
-    void sendEventChangeSignals(const CalendarData::Event &newEvent,
-                                const CalendarData::Event &oldEvent);
+    void sendEventChangeSignals(const CalendarData::Event &newEvent);
 
     QThread mWorkerThread;
     CalendarWorker *mCalendarWorker;
     QMultiHash<QString, CalendarData::Event> mEvents;
-    QMultiHash<QString, CalendarEvent *> mEventObjects;
+    QMultiHash<QString, CalendarStoredEvent *> mEventObjects;
     QHash<QString, CalendarData::EventOccurrence> mEventOccurrences;
     QHash<QDate, QStringList> mEventOccurrenceForDates;
     QList<CalendarAgendaModel *> mAgendaRefreshList;

--- a/src/calendarutils.h
+++ b/src/calendarutils.h
@@ -44,12 +44,6 @@
 
 namespace CalendarUtils {
 
-CalendarEvent::Recur convertRecurrence(const KCalendarCore::Event::Ptr &event);
-CalendarEvent::Days convertDayPositions(const KCalendarCore::Event::Ptr &event);
-CalendarEvent::Secrecy convertSecrecy(const KCalendarCore::Event::Ptr &event);
-CalendarEvent::Status convertStatus(const KCalendarCore::Event::Ptr &event);
-int getReminder(const KCalendarCore::Event::Ptr &event);
-QDateTime getReminderDateTime(const KCalendarCore::Event::Ptr &event);
 QList<CalendarData::Attendee> getEventAttendees(const KCalendarCore::Event::Ptr &event);
 QList<QObject*> convertAttendeeList(const QList<CalendarData::Attendee> &list);
 CalendarData::EventOccurrence getNextOccurrence(const KCalendarCore::Event::Ptr &event,

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -113,14 +113,10 @@ signals:
                                    const CalendarData::Event &eventData);
 
 private:
-    void setEventData(KCalendarCore::Event::Ptr &event, const CalendarData::Event &eventData);
     void loadNotebooks();
     QStringList excludedNotebooks() const;
     bool saveExcludeNotebook(const QString &notebookUid, bool exclude);
 
-    bool setRecurrence(KCalendarCore::Event::Ptr &event, CalendarEvent::Recur recur, CalendarEvent::Days days);
-    bool setReminder(KCalendarCore::Event::Ptr &event, int seconds, const QDateTime &dateTime);
-    bool setStatus(KCalendarCore::Event::Ptr &event, CalendarEvent::Status status);
     bool needSendCancellation(KCalendarCore::Event::Ptr &event) const;
     void updateEventAttendees(KCalendarCore::Event::Ptr event, bool newEvent,
                               const QList<CalendarData::EmailContact> &required,

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -118,7 +118,8 @@ public:
     void registerTypes(const char *uri)
     {
         Q_ASSERT(uri == QLatin1String("org.nemomobile.calendar"));
-        qmlRegisterUncreatableType<CalendarEvent>(uri, 1, 0, "CalendarEvent", "Create CalendarEvent instances through a model");
+        qmlRegisterUncreatableType<CalendarEvent>(uri, 1, 0, "CalendarEvent", "CalendarEvent is a base class");
+        qmlRegisterUncreatableType<CalendarStoredEvent>(uri, 1, 0, "CalendarStoredEvent", "Create CalendarEvent instances through a model");
         qmlRegisterUncreatableType<CalendarEventModification>(uri, 1, 0, "CalendarEventModification",
                                                                   "Create CalendarEventModification instances through Calendar API");
         qmlRegisterUncreatableType<CalendarChangeInformation>(uri, 1, 0, "CalendarChangeInformation",

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -224,7 +224,7 @@ void tst_CalendarEvent::testSave()
     query.setUniqueId(uid);
     QVERIFY(eventSpy.wait());
 
-    CalendarEvent *eventB = (CalendarEvent*) query.event();
+    CalendarStoredEvent *eventB = (CalendarStoredEvent*) query.event();
     QVERIFY(eventB != 0);
 
     // mKCal DB stores times as seconds, losing millisecond accuracy.
@@ -299,7 +299,7 @@ void tst_CalendarEvent::testTimeZone()
     query.setUniqueId(uid);
     QVERIFY(eventSpy.wait());
 
-    CalendarEvent *eventB = (CalendarEvent*) query.event();
+    CalendarStoredEvent *eventB = (CalendarStoredEvent*) query.event();
     QVERIFY(eventB != 0);
 
     QCOMPARE(eventB->endTime(), endTime);
@@ -356,7 +356,7 @@ void tst_CalendarEvent::testRecurrenceException()
     query.setStartTime(secondStart);
     QVERIFY(updated.wait());
 
-    CalendarEvent *savedEvent = (CalendarEvent*) query.event();
+    CalendarStoredEvent *savedEvent = (CalendarStoredEvent*) query.event();
     QVERIFY(savedEvent);
     QVERIFY(query.occurrence());
 
@@ -416,7 +416,7 @@ void tst_CalendarEvent::testRecurrenceException()
     QVERIFY(eventChangeSpy.count() > 0);
     QVERIFY(query.event());
 
-    recurrenceException = calendarApi->createModification(static_cast<CalendarEvent*>(query.event()));
+    recurrenceException = calendarApi->createModification(static_cast<CalendarStoredEvent*>(query.event()));
     QVERIFY(recurrenceException != 0);
 
     modifiedSecond = modifiedSecond.addSecs(20*60); // 12:30
@@ -620,7 +620,7 @@ void tst_CalendarEvent::testRecurrence()
     query.setUniqueId(uid);
     QVERIFY(eventSpy.wait());
 
-    CalendarEvent *event = (CalendarEvent*)query.event();
+    CalendarStoredEvent *event = (CalendarStoredEvent*)query.event();
     QVERIFY(event);
 
     QCOMPARE(event->recur(), recurType);
@@ -659,7 +659,7 @@ void tst_CalendarEvent::testRecurWeeklyDays()
     query.setUniqueId(uid);
     QVERIFY(eventSpy.wait());
 
-    CalendarEvent *event = (CalendarEvent*)query.event();
+    CalendarStoredEvent *event = (CalendarStoredEvent*)query.event();
     QVERIFY(event);
 
     QCOMPARE(event->recur(), CalendarEvent::RecurWeeklyByDays);
@@ -768,7 +768,7 @@ void tst_CalendarEvent::testAttendees()
     qDeleteAll(attendees);
 
     // Do a local modification, by removing participants and adding new.
-    eventMod = calendarApi->createModification(qobject_cast<CalendarEvent*>(query.event()));
+    eventMod = calendarApi->createModification(qobject_cast<CalendarStoredEvent*>(query.event()));
     QVERIFY(eventMod);
     required.remove(1); // Remove Bob
     optional.remove(0); // Remove Carl


### PR DESCRIPTION
…nt characteristics.

@pvuorela , this is a proposition to factorise a bit of code in nemo-qml-plugin-calendar.

Create a base class Event, based on CalendarData::Event struct,
from which inherit:
- a StoredEvent class for events owned by a Manager,
- a EventModification class to create new events or
  modify data from StoredEvent instances,
- a ImportEvent class for events read from ICS data
  and not stored on device.

These classes mainly reuse the existing code or
class layouts.

All code handling transformations from an to
KCalendarCore::Event have been gathered and moved
to the CalendarData::Event structure.

This last part is to avoid to have this transformation code scaterred in utils and worker, like it was before. Often, when adding a new member in CalendarData::Event structure to mirror one from KCalendarCore, I forgot to put it in utils, so it can be seen from CalendarImportEvent also for instance. And when moving away from CalendarData::Event in favour of KCalendarCore::Incidence, the affected code will be less scattered also.

What do you think ? As a bonus, it is reducing the code volume by 200 lines ;-)