### PR TITLE
[nemo-qml-plugin-calendar] Don't reload from DB when not needed.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.5.39
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.6.0
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -601,9 +601,8 @@ void CalendarManager::findMatchingEventFinished(const QString &invitationFile, c
     }
 }
 
-void CalendarManager::storageModifiedSlot(const QString &info)
+void CalendarManager::storageModifiedSlot()
 {
-    Q_UNUSED(info);
     mResetPending = true;
     emit storageModified();
 }

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -112,7 +112,7 @@ public:
     QList<CalendarData::Attendee> getEventAttendees(const QString &uid, const QDateTime &recurrenceId, bool *resultValid);
 
 private slots:
-    void storageModifiedSlot(const QString &info);
+    void storageModifiedSlot();
     void eventNotebookChanged(const QString &oldEventUid, const QString &newEventUid, const QString &notebookUid);
     void excludedNotebooksChangedSlot(const QStringList &excludedNotebooks);
     void notebooksChangedSlot(const QList<CalendarData::Notebook> &notebooks);

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -56,8 +56,10 @@ public:
 
     /* mKCal::ExtendedStorageObserver */
     void storageModified(mKCal::ExtendedStorage *storage, const QString &info);
-    void storageProgress(mKCal::ExtendedStorage *storage, const QString &info);
-    void storageFinished(mKCal::ExtendedStorage *storage, bool error, const QString &info);
+    void storageUpdated(mKCal::ExtendedStorage *storage,
+                        const KCalendarCore::Incidence::List &added,
+                        const KCalendarCore::Incidence::List &modified,
+                        const KCalendarCore::Incidence::List &deleted);
 
 public slots:
     void init();
@@ -88,7 +90,7 @@ public slots:
     void findMatchingEvent(const QString &invitationFile);
 
 signals:
-    void storageModifiedSignal(const QString &info);
+    void storageModifiedSignal();
 
     void eventNotebookChanged(const QString &oldEventUid, const QString &newEventUid, const QString &notebookUid);
 
@@ -137,10 +139,9 @@ private:
 
     QHash<QString, CalendarData::Notebook> mNotebooks;
 
-    // Tracks which events have been already passed to manager. Maps Uid -> RecurrenceId
-    QMultiHash<QString, QDateTime> mSentEvents;
-
-    bool mHasRecurringEvents;
+    // Tracks which events have been already passed to manager, using instanceIdentifiers.
+    QSet<QString> mSentEvents;
+    QSet<CalendarData::Range> mLoadedRanges;
 };
 
 #endif // CALENDARWORKER_H

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -192,7 +192,13 @@ void tst_CalendarEvent::testSave()
     eventMod->setLocation(location);
     QCOMPARE(eventMod->location(), location);
 
-    QDateTime endTime = QDateTime::currentDateTime();
+    QDateTime startTime = QDateTime::currentDateTime().addDays(-200);
+    const QTime at = startTime.time();
+    startTime.setTime(QTime(at.hour(), at.minute(), at.second()));
+    eventMod->setStartTime(startTime, Qt::LocalTime);
+    QCOMPARE(eventMod->startTime(), startTime);
+
+    QDateTime endTime = startTime.addSecs(3600);
     eventMod->setEndTime(endTime, Qt::LocalTime);
     QCOMPARE(eventMod->endTime(), endTime);
 
@@ -207,10 +213,6 @@ void tst_CalendarEvent::testSave()
     int reminder = 0; // at the time of the event
     eventMod->setReminder(reminder);
     QCOMPARE(eventMod->reminder(), reminder);
-
-    QDateTime startTime = QDateTime::currentDateTime();
-    eventMod->setStartTime(startTime, Qt::LocalTime);
-    QCOMPARE(eventMod->startTime(), startTime);
 
     QString uid;
     bool ok = saveEvent(eventMod, &uid);
@@ -478,12 +480,11 @@ void tst_CalendarEvent::testRecurrenceException()
     }
     QVERIFY(!modificationFound);
 
-    // ensure all gone, this emits two warning for not finding the two occurrences.
+    // ensure all is gone
     calendarApi->removeAll(uid);
-    QVERIFY(dataUpdated.wait());
+    QVERIFY(updated.wait());
+    QVERIFY(!query.event());
     mSavedEvents.remove(uid);
-    QVERIFY(!CalendarManager::instance()->getEvent(uid, QDateTime()).isValid());
-    QVERIFY(!CalendarManager::instance()->getEvent(uid, QDateTime::fromString(recurrenceException->recurrenceIdString(), Qt::ISODate)).isValid());
 
     delete recurrenceException;
     delete mod;

--- a/tests/tst_calendarmanager/tst_calendarmanager.cpp
+++ b/tests/tst_calendarmanager/tst_calendarmanager.cpp
@@ -586,13 +586,9 @@ void tst_CalendarManager::test_notebookApi()
         QVERIFY(uidList.contains(notebookPtr->uid()));
 
     QSignalSpy defaultNotebookSpy(mManager, SIGNAL(defaultNotebookChanged(QString)));
+    notebookSpy.clear();
     mManager->setDefaultNotebook(mAddedNotebooks.first()->uid());
-    for (int i = 0; i < 30; i++) {
-        if (notebookSpy.count() > 3)
-            break;
-
-        QTest::qWait(100);
-    }
+    QVERIFY(notebookSpy.wait());
     QCOMPARE(mManager->defaultNotebook(), mAddedNotebooks.first()->uid());
     QCOMPARE(defaultNotebookSpy.count(), 1);
 


### PR DESCRIPTION
The follow-up PR from sailfishos/mkcal#17 implementing the `storageUpdated` signal.

Basically, the major change is that when this signal is received, we're not flushing loaded ranges and notebooks, so on next `loadData()` call from the manager, we're not going to poke the DB. The rest is the same. I'm not taking any advantage of the added, modified or deleted lists at the moment. I don't know if it could be worth to do it in the future or not. For sure, it would add more complexity because we would need to get the internal storage of CalendarManager in sync. Maybe later when it will use KCalendarCore storage directly.

@pvuorela, it's still a bit WIP and I haven't tested it for real on device yet. But you may already give some feedback on design if you have time to think about it.