### PR TITLE
[nemo-qml-plugin-calendar] Fixup minor regression after factorisation…

### DIFF
--- a/src/calendareventmodification.cpp
+++ b/src/calendareventmodification.cpp
@@ -222,11 +222,6 @@ CalendarEventModification::replaceOccurrence(CalendarEventOccurrence *occurrence
                                                           m_requiredAttendees, m_optionalAttendees);
 }
 
-CalendarEvent::SyncFailureResolution CalendarEventModification::syncFailureResolution() const
-{
-    return mData->syncFailureResolution;
-}
-
 void CalendarEventModification::setSyncFailureResolution(CalendarEvent::SyncFailureResolution resolution)
 {
     if (mData->syncFailureResolution != resolution) {

--- a/src/calendareventmodification.h
+++ b/src/calendareventmodification.h
@@ -89,7 +89,6 @@ public:
 
     void setCalendarUid(const QString &uid);
 
-    CalendarEvent::SyncFailureResolution syncFailureResolution() const;
     void setSyncFailureResolution(CalendarEvent::SyncFailureResolution resolution);
 
     Q_INVOKABLE void setAttendees(CalendarContactModel *required, CalendarContactModel *optional);

--- a/src/calendarutils.cpp
+++ b/src/calendarutils.cpp
@@ -81,7 +81,9 @@ CalendarData::Event::Event(const KCalendarCore::Event &event)
         break;
     }
     const QString &failure = event.customProperty("VOLATILE", "SYNC-FAILURE");
-    if (failure.compare("upload", Qt::CaseInsensitive) == 0) {
+    if (failure.compare("upload-new", Qt::CaseInsensitive) == 0) {
+        syncFailure = CalendarEvent::CreationFailure;
+    } else if (failure.compare("upload", Qt::CaseInsensitive) == 0) {
         syncFailure = CalendarEvent::UploadFailure;
     } else if (failure.compare("update", Qt::CaseInsensitive) == 0) {
         syncFailure = CalendarEvent::UpdateFailure;


### PR DESCRIPTION
… commit

syncFailureResolution() was redefined in CalendarEventModification
without need.

upload-new corresponding to CreationFailure was missing in syncFailure
conversion code in utils.