### PR TITLE
[nemo-qml-plugin-calendar] Let mKCal optimise loading.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.6.0
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.6.2
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -92,7 +92,6 @@ void CalendarWorker::storageModified(mKCal::ExtendedStorage *storage, const QStr
 
     // External touch of the database. We have no clue what changed.
     // The mCalendar content has been wiped out already.
-    mLoadedRanges.clear();
     loadNotebooks();
     emit storageModifiedSignal();
 }
@@ -639,17 +638,8 @@ void CalendarWorker::loadData(const QList<CalendarData::Range> &ranges,
                               const QStringList &instanceList,
                               bool reset)
 {
-    if (!ranges.isEmpty() && mLoadedRanges.isEmpty()) {
-        // Load all recurring incidences,
-        // we have no other way to detect if they occur within a range
-        mStorage->loadRecurringIncidences();
-    }
-
     for (const CalendarData::Range &range : ranges) {
-        if (!mLoadedRanges.contains(range)) {
-            mStorage->load(range.first, range.second.addDays(1)); // end date is not inclusive
-            mLoadedRanges.insert(range);
-        }
+        mStorage->load(range.first, range.second.addDays(1)); // end date is not inclusive
     }
 
     foreach (const QString &id, instanceList) {

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -141,7 +141,6 @@ private:
 
     // Tracks which events have been already passed to manager, using instanceIdentifiers.
     QSet<QString> mSentEvents;
-    QSet<CalendarData::Range> mLoadedRanges;
 };
 
 #endif // CALENDARWORKER_H


### PR DESCRIPTION
mKCal is internally providing cache of loaded ranges
and recurring events since version 0.6.2. There is no
need anymore to optimise this in calendarworker.

@pvuorela, this is a follow-up of sailfishos/mkcal#19, but it requires a version bump in mkcal/CMakeLists.txt, to honour the pkgconfig(mkcal-qt5) >= 0.6.2.