### PR TITLE
Add a test on CalendarEvent modification signals and use uid/recid for sendResponse manager API.

### DIFF
--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -254,7 +254,12 @@ void CalendarStoredEvent::eventUidChanged(QString oldUid, QString newUid)
 
 bool CalendarStoredEvent::sendResponse(int response)
 {
-    return mManager->sendResponse(*mData, (Response)response);
+    if (mManager->sendResponse(mData->uniqueId, mData->recurrenceId, (Response)response)) {
+        mManager->save();
+        return true;
+    } else {
+        return false;
+    }
 }
 
 void CalendarStoredEvent::deleteEvent()

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -566,12 +566,13 @@ CalendarData::Event CalendarManager::getEvent(const QString &instanceIdentifier,
     return CalendarData::Event();
 }
 
-bool CalendarManager::sendResponse(const CalendarData::Event &eventData, CalendarEvent::Response response)
+bool CalendarManager::sendResponse(const QString &uid, const QDateTime &recurrenceId, CalendarEvent::Response response)
 {
     bool result;
     QMetaObject::invokeMethod(mCalendarWorker, "sendResponse", Qt::BlockingQueuedConnection,
                               Q_RETURN_ARG(bool, result),
-                              Q_ARG(CalendarData::Event, eventData),
+                              Q_ARG(QString, uid),
+                              Q_ARG(QDateTime, recurrenceId),
                               Q_ARG(CalendarEvent::Response, response));
     return result;
 }

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -76,7 +76,7 @@ public:
     CalendarData::Event getEvent(const QString& instanceIdentifier, bool *loaded = nullptr) const;
     CalendarData::Event getEvent(const QString& uid, const QDateTime &recurrenceId);
     CalendarData::Event dissociateSingleOccurrence(const QString &eventUid, const QDateTime &recurrenceId) const;
-    bool sendResponse(const CalendarData::Event &eventData, CalendarEvent::Response response);
+    bool sendResponse(const QString &uid, const QDateTime &recurrenceId, CalendarEvent::Response response);
 
     // Notebooks
     QList<CalendarData::Notebook> notebooks();

--- a/src/calendarutils.cpp
+++ b/src/calendarutils.cpp
@@ -541,20 +541,6 @@ CalendarEvent::Response CalendarUtils::convertPartStat(KCalendarCore::Attendee::
     }
 }
 
-KCalendarCore::Attendee::PartStat CalendarUtils::convertResponse(CalendarEvent::Response response)
-{
-    switch (response) {
-    case CalendarEvent::ResponseAccept:
-        return KCalendarCore::Attendee::Accepted;
-    case CalendarEvent::ResponseTentative:
-        return KCalendarCore::Attendee::Tentative;
-    case CalendarEvent::ResponseDecline:
-        return KCalendarCore::Attendee::Declined;
-    default:
-        return KCalendarCore::Attendee::NeedsAction;
-    }
-}
-
 CalendarEvent::Response CalendarUtils::convertResponseType(const QString &responseType)
 {
     // QString::toInt() conversion defaults to 0 on failure

--- a/src/calendarutils.h
+++ b/src/calendarutils.h
@@ -52,7 +52,6 @@ CalendarData::EventOccurrence getNextOccurrence(const KCalendarCore::Event::Ptr 
 bool importFromFile(const QString &fileName, KCalendarCore::Calendar::Ptr calendar);
 bool importFromIcsRawData(const QByteArray &icsData, KCalendarCore::Calendar::Ptr calendar);
 CalendarEvent::Response convertPartStat(KCalendarCore::Attendee::PartStat status);
-KCalendarCore::Attendee::PartStat convertResponse(CalendarEvent::Response response);
 CalendarEvent::Response convertResponseType(const QString &responseType);
 QString recurrenceIdToString(const QDateTime &dt);
 

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -152,28 +152,37 @@ void CalendarWorker::deleteAll(const QString &uid)
     mDeletedEvents.append(QPair<QString, QDateTime>(uid, QDateTime()));
 }
 
-bool CalendarWorker::sendResponse(const CalendarData::Event &eventData, const CalendarEvent::Response response)
+bool CalendarWorker::sendResponse(const QString &uid, const QDateTime &recurrenceId,
+                                  const CalendarEvent::Response response)
 {
-    KCalendarCore::Event::Ptr event = mCalendar->event(eventData.uniqueId, eventData.recurrenceId);
+    KCalendarCore::Event::Ptr event = mCalendar->event(uid, recurrenceId);
     if (!event) {
-        qWarning() << "Failed to send response, event not found. UID = " << eventData.uniqueId;
+        qWarning() << "Failed to send response, event not found. UID = " << uid;
         return false;
     }
-    const QString &notebookUid = mCalendar->notebook(event);
-    const QString &ownerEmail = mNotebooks.contains(notebookUid) ? mNotebooks.value(notebookUid).emailAddress
-                                                                 : QString();
-
+    const QString ownerEmail = mNotebooks.value(mCalendar->notebook(event)).emailAddress;
     const KCalendarCore::Attendee origAttendee = event->attendeeByMail(ownerEmail);
     KCalendarCore::Attendee updated = origAttendee;
-    updated.setStatus(CalendarUtils::convertResponse(response));
+    switch (response) {
+    case CalendarEvent::ResponseAccept:
+        updated.setStatus(KCalendarCore::Attendee::Accepted);
+        break;
+    case CalendarEvent::ResponseTentative:
+        updated.setStatus(KCalendarCore::Attendee::Tentative);
+        break;
+    case CalendarEvent::ResponseDecline:
+        updated.setStatus(KCalendarCore::Attendee::Declined);
+        break;
+    default:
+        updated.setStatus(KCalendarCore::Attendee::NeedsAction);
+    }
     updateAttendee(event, origAttendee, updated);
 
-    bool sent = mKCal::ServiceHandler::instance().sendResponse(event, eventData.description, mCalendar, mStorage);
+    bool sent = mKCal::ServiceHandler::instance().sendResponse(event, event->description(), mCalendar, mStorage);
 
     if (!sent)
         updateAttendee(event, updated, origAttendee);
 
-    save();
     return sent;
 }
 

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -71,7 +71,7 @@ public slots:
     CalendarData::Event dissociateSingleOccurrence(const QString &uid, const QDateTime &recurrenceId);
     void deleteEvent(const QString &uid, const QDateTime &recurrenceId, const QDateTime &dateTime);
     void deleteAll(const QString &uid);
-    bool sendResponse(const CalendarData::Event &eventData, const CalendarEvent::Response response);
+    bool sendResponse(const QString &uid, const QDateTime &recurrenceId, const CalendarEvent::Response response);
     QString convertEventToICalendar(const QString &uid, const QString &prodId) const;
 
     QList<CalendarData::Notebook> notebooks() const;

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -59,6 +59,7 @@ private slots:
 
     void modSetters();
     void testSave();
+    void testModify();
     void testTimeZone_data();
     void testTimeZone();
     void testRecurrenceException();
@@ -256,6 +257,34 @@ void tst_CalendarEvent::testSave()
     mSavedEvents.remove(uid);
 
     delete eventMod;
+}
+
+void tst_CalendarEvent::testModify()
+{
+    CalendarEventModification *eventMod = calendarApi->createNewEvent();
+    QVERIFY(eventMod != 0);
+
+    eventMod->setStartTime(QDateTime(QDate(2022, 3, 15), QTime(14, 9)), Qt::UTC);
+
+    QString uid;
+    QVERIFY(saveEvent(eventMod, &uid));
+    QVERIFY(!uid.isEmpty());
+    mSavedEvents.insert(uid);
+    delete eventMod;
+
+    CalendarEventQuery query;
+    QSignalSpy eventSpy(&query, &CalendarEventQuery::eventChanged);
+    query.setUniqueId(uid);
+    QVERIFY(eventSpy.wait());
+
+    CalendarStoredEvent *event = qobject_cast<CalendarStoredEvent*>(query.event());
+    QVERIFY(event);
+
+    QSignalSpy modSpy(event, &CalendarStoredEvent::startTimeChanged);
+    eventMod = calendarApi->createModification(event);
+    eventMod->setStartTime(QDateTime(QDate(2022, 3, 15), QTime(14, 13)), Qt::UTC);
+    eventMod->save();
+    QVERIFY(modSpy.wait());
 }
 
 void tst_CalendarEvent::testTimeZone_data()


### PR DESCRIPTION
The two commits from #30 that looks already good to go in.

I agree that the event->incidence commit in not very useful by itself since it would prepare to load todos and journals but this will not happen without moving to KCalendarCore storage in the manager. The same for the one replacing CalendarData::EmailContact with its KCalendarCore equivalent.

Besides, about your point that you tried to avoid KCalendarCore structures from the UI thread, I may add that they have move upstream away from `::Ptr` for many small structures, like attendees, persons… So They can now be used in the UI thread without risk and would avoid code duplication.