### PR TITLE
Use storage observer to do additional action on database changes

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -160,7 +160,7 @@ bool CalendarWorker::sendResponse(const QString &uid, const QDateTime &recurrenc
         qWarning() << "Failed to send response, event not found. UID = " << uid;
         return false;
     }
-    const QString ownerEmail = mNotebooks.value(mCalendar->notebook(event)).emailAddress;
+    const QString ownerEmail = getNotebookAddress(mCalendar->notebook(event));
     const KCalendarCore::Attendee origAttendee = event->attendeeByMail(ownerEmail);
     KCalendarCore::Attendee updated = origAttendee;
     switch (response) {
@@ -349,7 +349,7 @@ bool CalendarWorker::needSendCancellation(KCalendarCore::Event::Ptr &event) cons
         return false;
     }
     // we shouldn't send a response if we are not an organizer
-    if (calOrganizer.email() != getNotebookAddress(event)) {
+    if (calOrganizer.email() != getNotebookAddress(mCalendar->notebook(event))) {
         return false;
     }
     return true;
@@ -483,15 +483,7 @@ void CalendarWorker::updateEventAttendees(KCalendarCore::Event::Ptr event, bool 
 
 QString CalendarWorker::getNotebookAddress(const QString &notebookUid) const
 {
-    return mNotebooks.contains(notebookUid) ? mNotebooks.value(notebookUid).emailAddress
-                                            : QString();
-}
-
-QString CalendarWorker::getNotebookAddress(const KCalendarCore::Event::Ptr &event) const
-{
-    const QString &notebookUid = mCalendar->notebook(event);
-    return mNotebooks.contains(notebookUid) ? mNotebooks.value(notebookUid).emailAddress
-                                            : QString();
+    return mNotebooks.value(notebookUid).emailAddress;
 }
 
 QList<CalendarData::Notebook> CalendarWorker::notebooks() const
@@ -722,7 +714,7 @@ CalendarData::Event CalendarWorker::createEventStruct(const KCalendarCore::Event
     event.calendarUid = mCalendar->notebook(e);
     event.readOnly = mStorage->notebook(event.calendarUid)->isReadOnly();
     bool externalInvitation = false;
-    const QString &calendarOwnerEmail = getNotebookAddress(e);
+    const QString &calendarOwnerEmail = getNotebookAddress(event.calendarUid);
 
     KCalendarCore::Person organizer = e->organizer();
     const QString organizerEmail = organizer.email();

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -113,7 +113,7 @@ private:
     QStringList excludedNotebooks() const;
     bool saveExcludeNotebook(const QString &notebookUid, bool exclude);
 
-    bool needSendCancellation(const KCalendarCore::Incidence::Ptr &event) const;
+    bool isOrganizer(const KCalendarCore::Incidence::Ptr &event) const;
     void updateEventAttendees(KCalendarCore::Event::Ptr event, bool newEvent,
                               const QList<CalendarData::EmailContact> &required,
                               const QList<CalendarData::EmailContact> &optional,

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -119,7 +119,6 @@ private:
                               const QList<CalendarData::EmailContact> &optional,
                               const QString &notebookUid);
     QString getNotebookAddress(const QString &notebookUid) const;
-    QString getNotebookAddress(const KCalendarCore::Event::Ptr &event) const;
 
     CalendarData::Event createEventStruct(const KCalendarCore::Event::Ptr &event,
                                           mKCal::Notebook::Ptr notebook = mKCal::Notebook::Ptr()) const;

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -113,7 +113,7 @@ private:
     QStringList excludedNotebooks() const;
     bool saveExcludeNotebook(const QString &notebookUid, bool exclude);
 
-    bool needSendCancellation(KCalendarCore::Event::Ptr &event) const;
+    bool needSendCancellation(const KCalendarCore::Incidence::Ptr &event) const;
     void updateEventAttendees(KCalendarCore::Event::Ptr event, bool newEvent,
                               const QList<CalendarData::EmailContact> &required,
                               const QList<CalendarData::EmailContact> &optional,
@@ -130,11 +130,6 @@ private:
 
     mKCal::ExtendedCalendar::Ptr mCalendar;
     mKCal::ExtendedStorage::Ptr mStorage;
-
-    // mDeletedEvents is used to make sure
-    // that we are sending a cancellation email for events only
-    // when user actually saved (so truly deleted) changes by calling of save()
-    QList<QPair<QString, QDateTime>> mDeletedEvents;
 
     QHash<QString, CalendarData::Notebook> mNotebooks;
 


### PR DESCRIPTION
Following the introduction of `::storageUpdated()` from #28, one can now also use the callback method on database modification to actually perform complementary changes like purging deleted local events, or send invitations / updates / cancellations.

This avoids to store events marked as deleted and then try to see if they have actually been deleted to send cancellations fr instance. We're closer to the actual changes that happened in the database.

PS : the API of the service handler is slightly overly redundant : just the storage and the event would be enough. The calendar can be deduced from the storage with `storage->calendar()` and the notebook can also be deduced from the storage and the event with `storage->notebook(storage->calendar()->notebook(event))`.