### PR TITLE
[nemo-qml-plugin-calendar] Move away from Notebook::isDefault().

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -774,7 +774,8 @@ void CalendarWorker::loadNotebooks()
         notebook.uid = mkNotebook->uid();
         notebook.description = mkNotebook->description();
         notebook.emailAddress = mKCal::ServiceHandler::instance().emailAddress(mkNotebook, mStorage);
-        notebook.isDefault = mkNotebook->isDefault();
+        notebook.isDefault = mStorage->defaultNotebook()
+                && (mkNotebook->uid() == mStorage->defaultNotebook()->uid());
         notebook.readOnly = mkNotebook->isReadOnly();
         notebook.localCalendar = mkNotebook->isMaster()
                 && !mkNotebook->isShared()


### PR DESCRIPTION
In relation to sailfishos/mkcal#29 this is deprecating the use of Notebook::isDefault() and replacing it with something related to ExtendedStorage::defaultNotebook() only. @pvuorela, when you have time, thank you in advance.