### PR TITLE
[nemo-qml-plugin-calendar] Add an EXDATE to a recurring event when de…

### DIFF
--- a/src/calendareventquery.cpp
+++ b/src/calendareventquery.cpp
@@ -39,7 +39,7 @@
 #include <QDebug>
 
 CalendarEventQuery::CalendarEventQuery()
-    : mIsComplete(true), mOccurrence(0), mAttendeesCached(false), mEventError(false)
+    : mIsComplete(true), mOccurrence(0), mAttendeesCached(false), mEventError(false), mUpdateOccurrence(false)
 {
     connect(CalendarManager::instance(), SIGNAL(dataUpdated()), this, SLOT(refresh()));
     connect(CalendarManager::instance(), SIGNAL(storageModified()), this, SLOT(refresh()));
@@ -114,6 +114,7 @@ void CalendarEventQuery::setStartTime(const QDateTime &t)
     if (t == mStartTime)
         return;
     mStartTime = t;
+    mUpdateOccurrence = true;
     emit startTimeChanged();
 
     refresh();
@@ -167,7 +168,7 @@ void CalendarEventQuery::doRefresh(CalendarData::Event event, bool eventError)
     if (event.isValid() && (event.uniqueId != mUid || event.recurrenceId != mRecurrenceId))
         return;
 
-    bool updateOccurrence = false;
+    bool updateOccurrence = mUpdateOccurrence;
     bool signalEventChanged = false;
 
     if (event.uniqueId != mEvent.uniqueId || event.recurrenceId != mEvent.recurrenceId) {
@@ -197,6 +198,7 @@ void CalendarEventQuery::doRefresh(CalendarData::Event event, bool eventError)
                 mOccurrence->setParent(this);
             }
         }
+        mUpdateOccurrence = false;
         emit occurrenceChanged();
     }
 

--- a/src/calendareventquery.h
+++ b/src/calendareventquery.h
@@ -161,6 +161,7 @@ private:
     CalendarEventOccurrence *mOccurrence;
     bool mAttendeesCached;
     bool mEventError;
+    bool mUpdateOccurrence;
     QList<CalendarData::Attendee> mAttendees;
 };
 

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -386,6 +386,7 @@ void CalendarWorker::updateEventAttendees(KCalendarCore::Event::Ptr event, bool 
         event->setOrganizer(organizer);
     }
 
+    event->startUpdates();
     if (!newEvent) {
         // if existing attendees are removed, those should get a cancel update
         KCalendarCore::Event::Ptr cancelEvent = KCalendarCore::Event::Ptr(event->clone());
@@ -473,6 +474,7 @@ void CalendarWorker::updateEventAttendees(KCalendarCore::Event::Ptr event, bool 
             }
         }
     }
+    event->endUpdates();
 }
 
 QString CalendarWorker::getNotebookAddress(const QString &notebookUid) const


### PR DESCRIPTION
…leting an exception.

@pvuorela, following the discussion in sailfishos/mkcal#38 here is a PR adding an exdate to a parent event when deleting an exception.

Still WIP, I need to test it.