### PR TITLE
[nemo-qml-plugin-calendar] Add a thisAndFuture attribute to EventModi…

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -1,7 +1,7 @@
 Name:       nemo-qml-plugin-calendar-qt5
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.7.2
+Version:    0.7.9
 Release:    1
 License:    BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-calendar

--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -73,6 +73,7 @@ struct Event {
     QString instanceId; // A unique ID, used to identify an instance (incidence or exception) throughout calendars
     QString incidenceUid; // The uid of the incidence, shared between parent and exceptions
     QDateTime recurrenceId; // An id identifying an exception
+    bool thisAndFuture = false; // Used only when recurrenceId is valid.
     QString calendarUid; // The uid of the calendar the instance belong to
     QString location;
     CalendarEvent::Secrecy secrecy = CalendarEvent::SecrecyPublic;

--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -345,5 +345,13 @@ void CalendarStoredEvent::setEvent(const CalendarData::Event *data)
 
 CalendarData::Event CalendarStoredEvent::dissociateSingleOccurrence(const CalendarEventOccurrence *occurrence) const
 {
-    return occurrence ? m_manager->dissociateSingleOccurrence(m_data->instanceId, occurrence->startTime()) : CalendarData::Event();
+    if (occurrence && m_data->thisAndFuture) {
+        const QDateTime recId = occurrence->startTime().addSecs(m_data->startTime.secsTo(m_data->recurrenceId));
+        return m_manager->dissociateSingleOccurrence(m_data->instanceId, recId);
+    } else if (occurrence) {
+        return m_manager->dissociateSingleOccurrence(m_data->instanceId,
+                                                     occurrence->startTime());
+    } else {
+        return CalendarData::Event();
+    }
 }

--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -219,6 +219,11 @@ bool CalendarEvent::externalInvitation() const
     return m_data->externalInvitation;
 }
 
+bool CalendarEvent::thisAndFuture() const
+{
+    return m_data->thisAndFuture;
+}
+
 CalendarStoredEvent::CalendarStoredEvent(CalendarManager *manager, const CalendarData::Event *data)
     : CalendarEvent(data, manager)
     , m_manager(manager)
@@ -334,6 +339,8 @@ void CalendarStoredEvent::setEvent(const CalendarData::Event *data)
         emit ownerStatusChanged();
     if (m_data->syncFailure != old.syncFailure)
         emit syncFailureChanged();
+    if (m_data->thisAndFuture != old.thisAndFuture)
+        emit thisAndFutureChanged();
 }
 
 CalendarData::Event CalendarStoredEvent::dissociateSingleOccurrence(const CalendarEventOccurrence *occurrence) const

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -64,6 +64,7 @@ class CalendarEvent : public QObject
     Q_PROPERTY(QDateTime reminderDateTime READ reminderDateTime NOTIFY reminderDateTimeChanged)
     Q_PROPERTY(QString instanceId READ instanceId NOTIFY instanceIdChanged)
     Q_PROPERTY(bool isException READ isException CONSTANT)
+    Q_PROPERTY(bool thisAndFuture READ thisAndFuture NOTIFY thisAndFutureChanged)
     Q_PROPERTY(bool readOnly READ readOnly CONSTANT)
     Q_PROPERTY(QString calendarUid READ calendarUid NOTIFY calendarUidChanged)
     Q_PROPERTY(QString location READ location NOTIFY locationChanged)
@@ -162,6 +163,7 @@ public:
     QDateTime reminderDateTime() const;
     QString instanceId() const;
     bool isException() const;
+    bool thisAndFuture() const;
     virtual bool readOnly() const;
     QString calendarUid() const;
     QString location() const;
@@ -184,6 +186,7 @@ signals:
     void reminderDateTimeChanged();
     void instanceIdChanged();
     void calendarUidChanged();
+    void thisAndFutureChanged();
     void locationChanged();
     void recurEndDateChanged();
     void hasRecurEndDateChanged();

--- a/src/calendareventmodification.cpp
+++ b/src/calendareventmodification.cpp
@@ -139,6 +139,14 @@ void CalendarEventModification::setRecur(CalendarEvent::Recur recur)
     }
 }
 
+void CalendarEventModification::setThisAndFuture(bool thisAndFuture)
+{
+    if (m_data->thisAndFuture != thisAndFuture) {
+        m_data->thisAndFuture = thisAndFuture;
+        emit thisAndFutureChanged();
+    }
+}
+
 void CalendarEventModification::setRecurEndDate(const QDateTime &dateTime)
 {
     bool wasValid = m_data->recurEndDate.isValid();

--- a/src/calendareventmodification.h
+++ b/src/calendareventmodification.h
@@ -55,6 +55,7 @@ class CalendarEventModification : public CalendarEvent
     Q_PROPERTY(QString location READ location WRITE setLocation NOTIFY locationChanged)
     Q_PROPERTY(QString calendarUid READ calendarUid WRITE setCalendarUid NOTIFY calendarUidChanged)
     Q_PROPERTY(CalendarEvent::SyncFailureResolution syncFailureResolution READ syncFailureResolution WRITE setSyncFailureResolution NOTIFY syncFailureResolutionChanged)
+    Q_PROPERTY(bool thisAndFuture READ thisAndFuture WRITE setThisAndFuture NOTIFY thisAndFutureChanged)
 
 public:
     CalendarEventModification(const CalendarStoredEvent *source, const CalendarEventOccurrence *occurrence = 0, QObject *parent = 0);
@@ -74,6 +75,8 @@ public:
     void setAllDay(bool);
 
     void setRecur(CalendarEvent::Recur);
+
+    void setThisAndFuture(bool thisAndFuture);
 
     Q_INVOKABLE void setRecurEndDate(const QDateTime &dateTime);
     Q_INVOKABLE void unsetRecurEndDate();
@@ -109,6 +112,7 @@ signals:
     void hasRecurEndDateChanged();
     void calendarUidChanged();
     void syncFailureResolutionChanged();
+    void thisAndFutureChanged();
 
 private:
     bool m_attendeesSet = false;

--- a/src/calendarutils.cpp
+++ b/src/calendarutils.cpp
@@ -56,6 +56,7 @@ CalendarData::Event::Event(const KCalendarCore::Event &event)
     , instanceId(event.instanceIdentifier())
     , incidenceUid(event.uid())
     , recurrenceId(event.recurrenceId())
+    , thisAndFuture(event.thisAndFuture())
     , location(event.location())
 {
     switch (event.secrecy()) {

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -306,6 +306,7 @@ void CalendarWorker::saveEvent(const CalendarData::Event &eventData, bool update
             }
             event = KCalendarCore::Event::Ptr(parent->clone());
             event->setRecurrenceId(eventData.recurrenceId);
+            event->setThisAndFuture(eventData.thisAndFuture);
         } else {
             // The event was removed while changes were edited.
             // Options to either skip, as done now, or resurrect the event.

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -181,6 +181,18 @@ void CalendarWorker::deleteEvent(const QString &instanceId, const QDateTime &dat
         else
             event->recurrence()->addExDateTime(dateTime);
         event->setRevision(event->revision() + 1);
+    } else if (event->thisAndFuture() && dateTime.isValid() && dateTime != event->dtStart()) {
+        // We're deleting an occurrence after a this and future exception
+        // We treat it as an exDate to the parent.
+        KCalendarCore::Event::Ptr parent = m_calendar->event(event->uid());
+        if (parent) {
+            const QDateTime recId = dateTime.addSecs(event->dtStart().secsTo(event->recurrenceId()));
+            if (dateTime.timeSpec() == Qt::LocalTime && parent->dtStart().timeSpec() != Qt::LocalTime)
+                parent->recurrence()->addExDateTime(recId.toTimeZone(parent->dtStart().timeZone()));
+            else
+                parent->recurrence()->addExDateTime(recId);
+            parent->setRevision(parent->revision() + 1);
+        }
     } else if (event->hasRecurrenceId()) {
         // We consider that deleting an exception implies to create an exdate for the parent.
         KCalendarCore::Event::Ptr parent = m_calendar->event(event->uid());


### PR DESCRIPTION
…fication objects.

This attribute is used for EventModification objects created to modify an occurrence. It is saved to the database and allow to apply modifications to a recurring event for all future occurrences of a given date.

@pvuorela, it requires sailfishos/mkcal#46 to be built.