### PR TITLE
[nemo-qml-plugin-calendar] Since mKCal 0.7.6, load is loading the ful…

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -1,7 +1,7 @@
 Name:       nemo-qml-plugin-calendar-qt5
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.6.48
+Version:    0.6.53
 Release:    1
 License:    BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-calendar
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.6.2
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.6
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 

--- a/src/calendarimportmodel.cpp
+++ b/src/calendarimportmodel.cpp
@@ -208,7 +208,7 @@ bool CalendarImportModel::importToMemory(const QString &fileName, const QByteArr
     mEventList = cal->events(KCalendarCore::EventSortStartDate);
     // To avoid detach here, use qAsConst when available.
     for (const KCalendarCore::Event::Ptr &event : mEventList) {
-        mStorage->load(event->uid(), event->recurrenceId());
+        mStorage->load(event->uid());
         const KCalendarCore::Event::Ptr old =
             mStorage->calendar()->event(event->uid(), event->recurrenceId());
         if (old) {

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -514,8 +514,10 @@ void CalendarManager::deleteEvent(const QString &uid, const QDateTime &recurrenc
 
 void CalendarManager::deleteAll(const QString &uid)
 {
-    QMetaObject::invokeMethod(mCalendarWorker, "deleteAll", Qt::QueuedConnection,
-                              Q_ARG(QString, uid));
+    QMetaObject::invokeMethod(mCalendarWorker, "deleteEvent", Qt::QueuedConnection,
+                              Q_ARG(QString, uid),
+                              Q_ARG(QDateTime, QDateTime()),
+                              Q_ARG(QDateTime, QDateTime()));
 }
 
 void CalendarManager::save()

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -70,7 +70,6 @@ public slots:
                    const QList<CalendarData::EmailContact> &optional);
     CalendarData::Event dissociateSingleOccurrence(const QString &uid, const QDateTime &recurrenceId);
     void deleteEvent(const QString &uid, const QDateTime &recurrenceId, const QDateTime &dateTime);
-    void deleteAll(const QString &uid);
     bool sendResponse(const QString &uid, const QDateTime &recurrenceId, const CalendarEvent::Response response);
     QString convertEventToICalendar(const QString &uid, const QString &prodId) const;
 


### PR DESCRIPTION
…l series.

Don't use loadSeries() and load(uid, recid) from mKCal, since load(uid) is now always loading the parent and its exceptions.

@pvuorela, this is based on sailfishos/mkcal#47. It allow some simplifications in the code. Notice also that `mCalendar->deleteEventInstances()` is actually called by KCalendarCore internally when deleting a recurring event (see KCalendarCore/src/memorycalendar.cpp#230). So no need to call it here also.