### PR TITLE
[nemo-qml-plugin-calendar] Add a search model.

### DIFF
--- a/lightweight/calendardataservice/calendardataservice.pro
+++ b/lightweight/calendardataservice/calendardataservice.pro
@@ -14,6 +14,7 @@ HEADERS += \
     ../common/eventdata.h \
     ../../src/calendaragendamodel.h \
     ../../src/calendareventlistmodel.h \
+    ../../src/calendarsearchmodel.h \
     ../../src/calendarmanager.h \
     ../../src/calendarworker.h \
     ../../src/calendareventoccurrence.h \
@@ -28,6 +29,7 @@ SOURCES += \
     ../common/eventdata.cpp \
     ../../src/calendaragendamodel.cpp \
     ../../src/calendareventlistmodel.cpp \
+    ../../src/calendarsearchmodel.cpp \
     ../../src/calendarmanager.cpp \
     ../../src/calendarworker.cpp \
     ../../src/calendareventoccurrence.cpp \

--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -1,7 +1,7 @@
 Name:       nemo-qml-plugin-calendar-qt5
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.6.53
+Version:    0.6.56
 Release:    1
 License:    BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-calendar
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.6
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.14
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(timed-qt5)

--- a/src/calendareventlistmodel.cpp
+++ b/src/calendareventlistmodel.cpp
@@ -96,6 +96,11 @@ QStringList CalendarEventListModel::missingItems() const
     return mMissingItems;
 }
 
+bool CalendarEventListModel::loading() const
+{
+    return (mEventIdentifiers.count() + mMissingItems.count()) < mIdentifiers.count();
+}
+
 int CalendarEventListModel::count() const
 {
     return mEvents.size();
@@ -131,6 +136,7 @@ void CalendarEventListModel::doRefresh()
     endResetModel();
     emit countChanged();
     emit missingItemsChanged();
+    emit loadingChanged();
 }
 
 QVariant CalendarEventListModel::data(const QModelIndex &index, int role) const

--- a/src/calendareventlistmodel.h
+++ b/src/calendareventlistmodel.h
@@ -44,6 +44,7 @@ class CalendarEventListModel : public QAbstractListModel, public QQmlParserStatu
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(QStringList identifiers READ identifiers WRITE setIdentifiers NOTIFY identifiersChanged)
     Q_PROPERTY(QStringList missingItems READ missingItems NOTIFY missingItemsChanged)
+    Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
 public:
     enum EventListRoles {
@@ -63,6 +64,8 @@ public:
 
     QStringList missingItems() const;
 
+    bool loading() const;
+
     int rowCount(const QModelIndex &index) const;
     QVariant data(const QModelIndex &index, int role) const;
 
@@ -73,6 +76,7 @@ signals:
     void countChanged();
     void identifiersChanged();
     void missingItemsChanged();
+    virtual void loadingChanged();
 
 protected:
     virtual QHash<int, QByteArray> roleNames() const;

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -38,6 +38,7 @@
 #include "calendarevent.h"
 #include "calendaragendamodel.h"
 #include "calendareventlistmodel.h"
+#include "calendarsearchmodel.h"
 #include "calendareventoccurrence.h"
 #include "calendareventquery.h"
 #include "calendarinvitationquery.h"
@@ -80,6 +81,9 @@ CalendarManager::CalendarManager()
 
     connect(mCalendarWorker, &CalendarWorker::dataLoaded,
             this, &CalendarManager::dataLoadedSlot);
+
+    connect(mCalendarWorker, &CalendarWorker::searchResults,
+            this, &CalendarManager::onSearchResults);
 
     connect(mCalendarWorker, &CalendarWorker::findMatchingEventFinished,
             this, &CalendarManager::findMatchingEventFinished);
@@ -219,6 +223,41 @@ QString CalendarManager::getNotebookColor(const QString &notebookUid) const
         return mNotebooks.value(notebookUid, CalendarData::Notebook()).color;
     else
         return QString();
+}
+
+void CalendarManager::cancelSearch(CalendarSearchModel *model)
+{
+    mSearchList.removeOne(model);
+}
+
+void CalendarManager::search(CalendarSearchModel *model)
+{
+    if (mSearchList.contains(model))
+        return;
+
+    mSearchList.append(model);
+    QList<CalendarSearchModel*>::ConstIterator it;
+    for (it = mSearchList.constBegin(); it != mSearchList.constEnd(); it++) {
+        if (model != *it && model->searchString() == (*it)->searchString())
+            return;
+    }
+    QMetaObject::invokeMethod(mCalendarWorker, "search", Qt::QueuedConnection,
+                              Q_ARG(QString, model->searchString()));
+}
+
+void CalendarManager::onSearchResults(const QString &searchString,
+                                      const QStringList &identifiers)
+{
+    QList<CalendarSearchModel*>::Iterator it = mSearchList.begin();
+    while (it != mSearchList.end()) {
+        CalendarSearchModel *model = *it;
+        if (model->searchString() == searchString) {
+            it = mSearchList.erase(it);
+            model->setIdentifiers(identifiers);
+        } else {
+            it++;
+        }
+    }
 }
 
 void CalendarManager::cancelAgendaRefresh(CalendarAgendaModel *model)

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -242,7 +242,8 @@ void CalendarManager::search(CalendarSearchModel *model)
             return;
     }
     QMetaObject::invokeMethod(mCalendarWorker, "search", Qt::QueuedConnection,
-                              Q_ARG(QString, model->searchString()));
+                              Q_ARG(QString, model->searchString()),
+                              Q_ARG(int, model->limit()));
 }
 
 void CalendarManager::onSearchResults(const QString &searchString,

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -260,6 +260,11 @@ void CalendarManager::onSearchResults(const QString &searchString,
     }
 }
 
+bool CalendarManager::isSearching(const CalendarSearchModel *model) const
+{
+    return mSearchList.contains(const_cast<CalendarSearchModel*>(model));
+}
+
 void CalendarManager::cancelAgendaRefresh(CalendarAgendaModel *model)
 {
     mAgendaRefreshList.removeOne(model);

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -100,6 +100,7 @@ public:
     // SearchModel
     void cancelSearch(CalendarSearchModel *model);
     void search(CalendarSearchModel *model);
+    bool isSearching(const CalendarSearchModel *model) const;
 
     // EventQuery
     void scheduleEventQueryRefresh(CalendarEventQuery *query);

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -49,6 +49,7 @@ class CalendarEventListModel;
 class CalendarEventOccurrence;
 class CalendarEventQuery;
 class CalendarInvitationQuery;
+class CalendarSearchModel;
 
 class CalendarManager : public QObject
 {
@@ -96,6 +97,10 @@ public:
     void cancelEventListRefresh(CalendarEventListModel *model);
     void scheduleEventListRefresh(CalendarEventListModel *model);
 
+    // SearchModel
+    void cancelSearch(CalendarSearchModel *model);
+    void search(CalendarSearchModel *model);
+
     // EventQuery
     void scheduleEventQueryRefresh(CalendarEventQuery *query);
     void cancelEventQueryRefresh(CalendarEventQuery *query);
@@ -126,6 +131,7 @@ private slots:
     void timeout();
     void findMatchingEventFinished(const QString &invitationFile,
                                    const CalendarData::Event &event);
+    void onSearchResults(const QString &searchString, const QStringList &identifiers);
 
 signals:
     void excludedNotebooksChanged(QStringList excludedNotebooks);
@@ -157,6 +163,7 @@ private:
     QList<CalendarAgendaModel *> mAgendaRefreshList;
     QList<CalendarEventListModel *> mEventListRefreshList;
     QList<CalendarEventQuery *> mQueryRefreshList;
+    QList<CalendarSearchModel *> mSearchList;
     QHash<CalendarInvitationQuery *, QString> mInvitationQueryHash; // value is the invitationFile.
     QStringList mExcludedNotebooks;
     QHash<QString, CalendarData::Notebook> mNotebooks;

--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -54,10 +54,23 @@ void CalendarSearchModel::setSearchString(const QString &searchString)
     setIdentifiers(QStringList());
     if (!mSearchString.isEmpty()) {
         CalendarManager::instance()->search(this);
+        emit loadingChanged();
     }
 }
 
 QString CalendarSearchModel::searchString() const
 {
     return mSearchString;
+}
+
+void CalendarSearchModel::setIdentifiers(const QStringList &ids)
+{
+    CalendarEventListModel::setIdentifiers(ids);
+    emit loadingChanged();
+}
+
+bool CalendarSearchModel::loading() const
+{
+    return CalendarManager::instance()->isSearching(this)
+        || CalendarEventListModel::loading();
 }

--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -63,6 +63,25 @@ QString CalendarSearchModel::searchString() const
     return mSearchString;
 }
 
+int CalendarSearchModel::limit() const
+{
+    return mLimit;
+}
+
+void CalendarSearchModel::setLimit(int limit)
+{
+    if (limit == mLimit)
+        return;
+
+    mLimit = limit;
+    emit limitChanged();
+
+    if (!mSearchString.isEmpty()) {
+        CalendarManager::instance()->search(this);
+        emit loadingChanged();
+    }
+}
+
 void CalendarSearchModel::setIdentifiers(const QStringList &ids)
 {
     CalendarEventListModel::setIdentifiers(ids);

--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Damien Caliste <dcaliste@free.fr>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendarsearchmodel.h"
+
+#include "calendarmanager.h"
+
+CalendarSearchModel::CalendarSearchModel(QObject *parent)
+    : CalendarEventListModel(parent)
+{
+}
+
+CalendarSearchModel::~CalendarSearchModel()
+{
+    CalendarManager::instance()->cancelSearch(this);
+}
+
+void CalendarSearchModel::setSearchString(const QString &searchString)
+{
+    if (searchString == mSearchString)
+        return;
+
+    mSearchString = searchString;
+    emit searchStringChanged();
+
+    setIdentifiers(QStringList());
+    if (!mSearchString.isEmpty()) {
+        CalendarManager::instance()->search(this);
+    }
+}
+
+QString CalendarSearchModel::searchString() const
+{
+    return mSearchString;
+}

--- a/src/calendarsearchmodel.h
+++ b/src/calendarsearchmodel.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Damien Caliste <dcaliste@free.fr>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDARSEARCHMODEL_H
+#define CALENDARSEARCHMODEL_H
+
+#include "calendareventlistmodel.h"
+
+class CalendarSearchModel : public CalendarEventListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QString searchString READ searchString WRITE setSearchString NOTIFY searchStringChanged)
+
+public:
+    CalendarSearchModel(QObject *parent = 0);
+    ~CalendarSearchModel();
+
+    QString searchString() const;
+    void setSearchString(const QString &pattern);
+
+signals:
+    void searchStringChanged();
+
+private:
+    QString mSearchString;
+};
+
+#endif

--- a/src/calendarsearchmodel.h
+++ b/src/calendarsearchmodel.h
@@ -38,6 +38,7 @@ class CalendarSearchModel : public CalendarEventListModel
 {
     Q_OBJECT
     Q_PROPERTY(QString searchString READ searchString WRITE setSearchString NOTIFY searchStringChanged)
+    Q_PROPERTY(int limit READ limit WRITE setLimit NOTIFY limitChanged)
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
 public:
@@ -47,6 +48,9 @@ public:
     QString searchString() const;
     void setSearchString(const QString &pattern);
 
+    int limit() const;
+    void setLimit(int limit);
+
     void setIdentifiers(const QStringList &ids);
 
     bool loading() const;
@@ -54,9 +58,11 @@ public:
 signals:
     void searchStringChanged();
     void loadingChanged();
+    void limitChanged();
 
 private:
     QString mSearchString;
+    int mLimit = 0;
 };
 
 #endif

--- a/src/calendarsearchmodel.h
+++ b/src/calendarsearchmodel.h
@@ -38,6 +38,7 @@ class CalendarSearchModel : public CalendarEventListModel
 {
     Q_OBJECT
     Q_PROPERTY(QString searchString READ searchString WRITE setSearchString NOTIFY searchStringChanged)
+    Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
 public:
     CalendarSearchModel(QObject *parent = 0);
@@ -46,8 +47,13 @@ public:
     QString searchString() const;
     void setSearchString(const QString &pattern);
 
+    void setIdentifiers(const QStringList &ids);
+
+    bool loading() const;
+
 signals:
     void searchStringChanged();
+    void loadingChanged();
 
 private:
     QString mSearchString;

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -752,12 +752,12 @@ CalendarData::Event CalendarWorker::createEventStruct(const KCalendarCore::Event
     return event;
 }
 
-void CalendarWorker::search(const QString &searchString)
+void CalendarWorker::search(const QString &searchString, int limit)
 {
     QStringList identifiers;
     QMultiHash<QString, CalendarData::Event> events;
 
-    if (mStorage->search(searchString, &identifiers)) {
+    if (mStorage->search(searchString, &identifiers, limit)) {
         emit searchResults(searchString, identifiers);
     }
 

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -85,6 +85,8 @@ public slots:
     void loadData(const QList<CalendarData::Range> &ranges,
                   const QStringList &instanceList, bool reset);
 
+    void search(const QString &searchString);
+
     CalendarData::EventOccurrence getNextOccurrence(const QString &uid, const QDateTime &recurrenceId,
                                                     const QDateTime &startTime) const;
     QList<CalendarData::Attendee> getEventAttendees(const QString &uid, const QDateTime &recurrenceId);
@@ -108,6 +110,8 @@ signals:
                     const QHash<QString, CalendarData::EventOccurrence> &occurrences,
                     const QHash<QDate, QStringList> &dailyOccurrences,
                     bool reset);
+
+    void searchResults(const QString &searchString, const QStringList &identifiers);
 
     void findMatchingEventFinished(const QString &invitationFile,
                                    const CalendarData::Event &eventData);

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -85,7 +85,7 @@ public slots:
     void loadData(const QList<CalendarData::Range> &ranges,
                   const QStringList &instanceList, bool reset);
 
-    void search(const QString &searchString);
+    void search(const QString &searchString, int limit);
 
     CalendarData::EventOccurrence getNextOccurrence(const QString &uid, const QDateTime &recurrenceId,
                                                     const QDateTime &startTime) const;

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -43,6 +43,7 @@
 #include "calendareventmodification.h"
 #include "calendaragendamodel.h"
 #include "calendareventlistmodel.h"
+#include "calendarsearchmodel.h"
 #include "calendarmanager.h"
 #include "calendarnotebookquery.h"
 #include "calendarimportmodel.h"
@@ -124,6 +125,7 @@ public:
                                                                   "Create CalendarEventModification instances through Calendar API");
         qmlRegisterType<CalendarAgendaModel>(uri, 1, 0, "AgendaModel");
         qmlRegisterType<CalendarEventListModel>(uri, 1, 0, "EventListModel");
+        qmlRegisterType<CalendarSearchModel>(uri, 1, 0, "EventSearchModel");
         qmlRegisterType<CalendarEventQuery>(uri, 1, 0, "EventQuery");
         qmlRegisterType<CalendarInvitationQuery>(uri, 1, 0, "InvitationQuery");
         qmlRegisterUncreatableType<Person>(uri, 1, 0, "Person", "Persons reachable only through EventQuery");

--- a/src/src.pro
+++ b/src/src.pro
@@ -30,6 +30,7 @@ SOURCES += \
     $$SRCDIR/calendareventoccurrence.cpp \
     $$SRCDIR/calendaragendamodel.cpp \
     $$SRCDIR/calendareventlistmodel.cpp \
+    $$SRCDIR/calendarsearchmodel.cpp \
     $$SRCDIR/calendarapi.cpp \
     $$SRCDIR/calendareventquery.cpp \
     $$SRCDIR/calendarinvitationquery.cpp \
@@ -49,6 +50,7 @@ HEADERS += \
     $$SRCDIR/calendareventoccurrence.h \
     $$SRCDIR/calendaragendamodel.h \
     $$SRCDIR/calendareventlistmodel.h \
+    $$SRCDIR/calendarsearchmodel.h \
     $$SRCDIR/calendarapi.h \
     $$SRCDIR/calendareventquery.h \
     $$SRCDIR/calendarinvitationquery.h \

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -3,7 +3,8 @@ SUBDIRS = \
     tst_calendarmanager \
     tst_calendarevent \
     tst_calendaragendamodel \
-    tst_calendarimportmodel
+    tst_calendarimportmodel \
+    tst_calendarsearchmodel
 
 tests_xml.path = /opt/tests/nemo-qml-plugins-qt5/calendar
 tests_xml.files = tests.xml

--- a/tests/tst_calendarsearchmodel/tst_calendarsearchmodel.cpp
+++ b/tests/tst_calendarsearchmodel/tst_calendarsearchmodel.cpp
@@ -1,0 +1,66 @@
+#include <QObject>
+#include <QtTest>
+#include <QQmlEngine>
+#include <QSignalSpy>
+
+#include "calendarapi.h"
+#include "calendarmanager.h"
+#include "calendarsearchmodel.h"
+
+#include "plugin.cpp"
+
+class tst_CalendarSearchModel : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+
+    void test_searchString();
+
+private:
+    QQmlEngine *engine;
+    CalendarApi *calendarApi;
+    QSet<QString> mSavedEvents;
+};
+
+void tst_CalendarSearchModel::initTestCase()
+{
+    // Create plugin, it shuts down the DB in proper order
+    engine = new QQmlEngine(this);
+    NemoCalendarPlugin* plugin = new NemoCalendarPlugin();
+    plugin->initializeEngine(engine, "foobar");
+    calendarApi = new CalendarApi(this);
+
+    // Use test plugins, instead of mKCal ones.
+    if (qgetenv("MKCAL_PLUGIN_DIR").isEmpty())
+        qputenv("MKCAL_PLUGIN_DIR", "plugins");
+
+    QSignalSpy modified(CalendarManager::instance(),
+                        &CalendarManager::storageModified);
+    CalendarEventModification *event = calendarApi->createNewEvent();
+    QVERIFY(event != 0);
+    event->setDisplayLabel(QString::fromLatin1("Summary with string 'azerty' %plop."));
+    event->save();
+    QVERIFY(modified.wait());
+}
+
+void tst_CalendarSearchModel::test_searchString()
+{
+    CalendarSearchModel *model = new CalendarSearchModel(this);
+    QSignalSpy searchStringSet(model, &CalendarSearchModel::searchStringChanged);
+    QSignalSpy identifiersSet(model, &CalendarSearchModel::identifiersChanged);
+    QSignalSpy countSet(model, &CalendarSearchModel::countChanged);
+
+    QVERIFY(model->identifiers().isEmpty());
+    model->setSearchString(QString::fromLatin1("azerty' %p"));
+    QCOMPARE(searchStringSet.count(), 1);
+    QVERIFY(identifiersSet.wait());
+    QCOMPARE(model->identifiers().length(), 1);
+    QVERIFY(countSet.wait());
+    QCOMPARE(model->count(), 1);
+}
+
+
+#include "tst_calendarsearchmodel.moc"
+QTEST_MAIN(tst_CalendarSearchModel)

--- a/tests/tst_calendarsearchmodel/tst_calendarsearchmodel.pro
+++ b/tests/tst_calendarsearchmodel/tst_calendarsearchmodel.pro
@@ -1,0 +1,4 @@
+include(../common.pri)
+
+TARGET = tst_calendarsearchmodel
+SOURCES += tst_calendarsearchmodel.cpp


### PR DESCRIPTION
Add a search function to CalendarManager. It is based on ExtendedStorage::search() method. The worker is loading all matching incidences and retrieving the corresponding instance identifiers. The later are
passed back to the manager via a new searchResults signal. While the former are sent back viw the
existing dataLoaded signal.

Also add a model listing occurrence of a search
query. This model is based on a EventListModel
where the identifiers are given as the result of
a search call.

@pvuorela, this is based on sailfishos/mkcal#49 and aims at providing a list model for search results. It is conveniently based on evntlistmodel, since such model already provide event listing from instance identifiers. I still keep this as WIP since I would like to add a loading property to the eventlistmodel. But having it public already should help to see how the mkcal PR is working in reality.