### PR TITLE
[nemo-calendar] Remove deprecated use of Incidence::setHasGeo(). Fixes JB#60292

### DIFF
--- a/tools/icalconverter/main.cpp
+++ b/tools/icalconverter/main.cpp
@@ -330,7 +330,6 @@ namespace CalendarImportExport {
             COPY_IF_NOT_EQUAL(dest, src, description(), setDescription);
             COPY_IF_NOT_EQUAL(dest, src, geoLatitude(), setGeoLatitude);
             COPY_IF_NOT_EQUAL(dest, src, geoLongitude(), setGeoLongitude);
-            COPY_IF_NOT_EQUAL(dest, src, hasGeo(), setHasGeo);
             COPY_IF_NOT_EQUAL(dest, src, location(), setLocation);
             COPY_IF_NOT_EQUAL(dest, src, resources(), setResources);
             COPY_IF_NOT_EQUAL(dest, src, secrecy(), setSecrecy);


### PR DESCRIPTION
No-op if bool parameter is true and otherwise there area lready calls to setGeoLatitude/Longitude.

@dcaliste 