### PR TITLE
[nemo-qml-plugin-calendar] Reset calendar on timezone change on device.

### DIFF
--- a/lightweight/calendardataservice/calendardataservice.pro
+++ b/lightweight/calendardataservice/calendardataservice.pro
@@ -5,7 +5,7 @@ target.path = /usr/bin
 QT += qml dbus
 QT -= gui
 
-CONFIG += link_pkgconfig
+CONFIG += link_pkgconfig timed-qt5
 PKGCONFIG += KF5CalendarCore libmkcal-qt5 accounts-qt5
 
 HEADERS += \

--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -13,6 +13,7 @@ BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.6
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
+BuildRequires:  pkgconfig(timed-qt5)
 
 %description
 %{summary}.

--- a/src/calendaragendamodel.cpp
+++ b/src/calendaragendamodel.cpp
@@ -44,6 +44,8 @@ CalendarAgendaModel::CalendarAgendaModel(QObject *parent)
 {
     connect(CalendarManager::instance(), SIGNAL(storageModified()), this, SLOT(refresh()));
     connect(CalendarManager::instance(), SIGNAL(dataUpdated()), this, SLOT(refresh()));
+    connect(CalendarManager::instance(), &CalendarManager::timezoneChanged,
+            this, &CalendarAgendaModel::onTimezoneChanged);
 }
 
 CalendarAgendaModel::~CalendarAgendaModel()
@@ -283,6 +285,18 @@ QVariant CalendarAgendaModel::get(int index, int role) const
     default:
         qWarning() << "CalendarAgendaModel: Unknown role asked";
         return QVariant();
+    }
+}
+
+void CalendarAgendaModel::onTimezoneChanged()
+{
+    QList<CalendarEventOccurrence *>::ConstIterator it;
+    for (it = mEvents.constBegin(); it != mEvents.constEnd(); it++) {
+        // Actually, the date times have not changed, but
+        // their representations in local time (as used in QML)
+        // have changed.
+        (*it)->startTimeChanged();
+        (*it)->endTimeChanged();
     }
 }
 

--- a/src/calendaragendamodel.h
+++ b/src/calendaragendamodel.h
@@ -103,6 +103,7 @@ protected:
 
 private slots:
     void refresh();
+    void onTimezoneChanged();
 
 private:
     QDate mStartDate;

--- a/src/calendareventlistmodel.cpp
+++ b/src/calendareventlistmodel.cpp
@@ -43,6 +43,8 @@ CalendarEventListModel::CalendarEventListModel(QObject *parent)
             this, &CalendarEventListModel::refresh);
     connect(CalendarManager::instance(), &CalendarManager::dataUpdated,
             this, &CalendarEventListModel::doRefresh);
+    connect(CalendarManager::instance(), &CalendarManager::timezoneChanged,
+            this, &CalendarEventListModel::onTimezoneChanged);
 }
 
 CalendarEventListModel::~CalendarEventListModel()
@@ -151,6 +153,18 @@ QVariant CalendarEventListModel::data(const QModelIndex &index, int role) const
     default:
         qWarning() << "CalendarEventListModel: Unknown role asked";
         return QVariant();
+    }
+}
+
+void CalendarEventListModel::onTimezoneChanged()
+{
+    QList<CalendarEventOccurrence *>::ConstIterator it;
+    for (it = mEvents.constBegin(); it != mEvents.constEnd(); it++) {
+        // Actually, the date times have not changed, but
+        // their representations in local time (as used in QML)
+        // have changed.
+        (*it)->startTimeChanged();
+        (*it)->endTimeChanged();
     }
 }
 

--- a/src/calendareventlistmodel.h
+++ b/src/calendareventlistmodel.h
@@ -79,6 +79,7 @@ protected:
 
 private slots:
     void doRefresh();
+    void onTimezoneChanged();
 
 private:
     void refresh();

--- a/src/calendareventoccurrence.h
+++ b/src/calendareventoccurrence.h
@@ -42,8 +42,8 @@ class CalendarEventOccurrence : public QObject
 {
     Q_OBJECT
     // startTime and endTime are givent in local time.
-    Q_PROPERTY(QDateTime startTime READ startTime CONSTANT)
-    Q_PROPERTY(QDateTime endTime READ endTime CONSTANT)
+    Q_PROPERTY(QDateTime startTime READ startTime NOTIFY startTimeChanged)
+    Q_PROPERTY(QDateTime endTime READ endTime NOTIFY endTimeChanged)
     // startTimeInTz and endTimeInTz are given in event startTime / endTime timezone
     Q_PROPERTY(QDateTime startTimeInTz READ startTimeInTz CONSTANT)
     Q_PROPERTY(QDateTime endTimeInTz READ endTimeInTz CONSTANT)
@@ -62,6 +62,10 @@ public:
     QDateTime startTimeInTz() const;
     QDateTime endTimeInTz() const;
     CalendarStoredEvent *eventObject() const;
+
+signals:
+    void startTimeChanged();
+    void endTimeChanged();
 
 private slots:
     void eventUidChanged(QString oldUid, QString newUid);

--- a/src/calendareventquery.cpp
+++ b/src/calendareventquery.cpp
@@ -43,6 +43,8 @@ CalendarEventQuery::CalendarEventQuery()
 {
     connect(CalendarManager::instance(), SIGNAL(dataUpdated()), this, SLOT(refresh()));
     connect(CalendarManager::instance(), SIGNAL(storageModified()), this, SLOT(refresh()));
+    connect(CalendarManager::instance(), &CalendarManager::timezoneChanged,
+            this, &CalendarEventQuery::onTimezoneChanged);
 
     connect(CalendarManager::instance(), SIGNAL(eventUidChanged(QString,QString)),
             this, SLOT(eventUidChanged(QString,QString)));
@@ -237,6 +239,17 @@ void CalendarEventQuery::refresh()
         return;
 
     CalendarManager::instance()->scheduleEventQueryRefresh(this);
+}
+
+void CalendarEventQuery::onTimezoneChanged()
+{
+    if (mOccurrence) {
+        // Actually, the date times have not changed, but
+        // their representations in local time (as used in QML)
+        // have changed.
+        mOccurrence->startTimeChanged();
+        mOccurrence->endTimeChanged();
+    }
 }
 
 void CalendarEventQuery::eventUidChanged(QString oldUid, QString newUid)

--- a/src/calendareventquery.h
+++ b/src/calendareventquery.h
@@ -150,6 +150,7 @@ signals:
 
 private slots:
     void refresh();
+    void onTimezoneChanged();
     void eventUidChanged(QString oldUid, QString newUid);
 
 private:

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -67,6 +67,9 @@ CalendarManager::CalendarManager()
     connect(mCalendarWorker, &CalendarWorker::storageModifiedSignal,
             this, &CalendarManager::storageModifiedSlot);
 
+    connect(mCalendarWorker, &CalendarWorker::calendarTimezoneChanged,
+            this, &CalendarManager::calendarTimezoneChangedSlot);
+
     connect(mCalendarWorker, &CalendarWorker::eventNotebookChanged,
             this, &CalendarManager::eventNotebookChanged);
 
@@ -613,6 +616,21 @@ void CalendarManager::storageModifiedSlot()
 {
     mResetPending = true;
     emit storageModified();
+}
+
+void CalendarManager::calendarTimezoneChangedSlot()
+{
+    QMultiHash<QString, CalendarStoredEvent *>::ConstIterator it;
+    for (it = mEventObjects.constBegin(); it != mEventObjects.constEnd(); it++) {
+        // Actually, the date times have not changed, but
+        // their representation in local time (as used in QML)
+        // have changed.
+        if ((*it)->startTimeSpec() != Qt::LocalTime)
+            (*it)->startTimeChanged();
+        if ((*it)->endTimeSpec() != Qt::LocalTime)
+            (*it)->endTimeChanged();
+    }
+    emit timezoneChanged();
 }
 
 void CalendarManager::eventNotebookChanged(const QString &oldEventUid, const QString &newEventUid,

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -113,6 +113,7 @@ public:
 
 private slots:
     void storageModifiedSlot();
+    void calendarTimezoneChangedSlot();
     void eventNotebookChanged(const QString &oldEventUid, const QString &newEventUid, const QString &notebookUid);
     void excludedNotebooksChangedSlot(const QStringList &excludedNotebooks);
     void notebooksChangedSlot(const QList<CalendarData::Notebook> &notebooks);
@@ -133,6 +134,7 @@ signals:
     void notebookColorChanged(QString notebookUid);
     void defaultNotebookChanged(QString notebookUid);
     void storageModified();
+    void timezoneChanged();
     void dataUpdated();
     void eventUidChanged(QString oldUid, QString newUid);
 

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -44,6 +44,9 @@
 // libaccounts-qt
 namespace Accounts { class Manager; }
 
+// To get notified about timezone changes
+#include <timed-qt5/wall-declarations.h>
+
 class CalendarInvitationQuery;
 
 class CalendarWorker : public QObject, public mKCal::ExtendedStorageObserver
@@ -87,9 +90,11 @@ public slots:
     QList<CalendarData::Attendee> getEventAttendees(const QString &uid, const QDateTime &recurrenceId);
 
     void findMatchingEvent(const QString &invitationFile);
+    void onTimedSignal(const Maemo::Timed::WallClock::Info &info, bool time_changed);
 
 signals:
     void storageModifiedSignal();
+    void calendarTimezoneChanged();
 
     void eventNotebookChanged(const QString &oldEventUid, const QString &newEventUid, const QString &notebookUid);
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -2,7 +2,7 @@ TARGET = nemocalendar
 PLUGIN_IMPORT_PATH = org/nemomobile/calendar
 
 TEMPLATE = lib
-CONFIG += qt plugin hide_symbols
+CONFIG += qt plugin hide_symbols timed-qt5
 
 QT += qml concurrent
 QT -= gui


### PR DESCRIPTION
Create a hard dependency on Timed to get the timezone change info.

@pvuorela : this is allowing to change the timezone in the system setting on device and the calendar still displays events at the right date and time. If the event is floating, no change is done. If the event is given by UTC or in a timezone, the display time is shifted accordingly. If it requires a date change, the event is moved and agenda models are updated accordingly. Maybe you have a long standing JB id available for this ? ;-)

The `emitStorageModified()` may seem a bit overkill, but the caching mechanism in mKCal will make it much less resource intensive. The ranges won't be reloaded for instance, just the occurrences will be recomputed (which is desired). All the events by UID will be reloaded though. I may add a safeguard in mKCal for this also : there is no necessity to reload an event that we already have in the calendar. Either it's not modified and it's a possibly blocking call to read the DB to get the same data, or the DB has been modified externally and anyway the calendar has been flushed already and emptied from any events.