### PR TITLE
Use next occurrence for recurring events in search

### DIFF
--- a/src/calendareventlistmodel.cpp
+++ b/src/calendareventlistmodel.cpp
@@ -148,14 +148,9 @@ void CalendarEventListModel::doRefresh()
         bool loaded;
         CalendarData::Event event = CalendarManager::instance()->getEvent(id, &loaded);
         if (event.isValid()) {
-            CalendarEventOccurrence *occurrence;
-            if (event.recur != CalendarEvent::RecurOnce && mStartTime.isValid()) {
-                occurrence = CalendarManager::instance()->getNextOccurrence
-                    (event.uniqueId, event.recurrenceId, mStartTime);
-            } else {
-                occurrence = new CalendarEventOccurrence(event.uniqueId, event.recurrenceId,
-                                                         event.startTime, event.endTime, this);
-            }
+            CalendarEventOccurrence *occurrence =
+                CalendarManager::instance()->getNextOccurrence
+                (event.uniqueId, event.recurrenceId, mStartTime);
             if (occurrence->startTime().isValid()) {
                 occurrence->setProperty("identifier", id);
                 mEvents.append(occurrence);

--- a/src/calendareventlistmodel.h
+++ b/src/calendareventlistmodel.h
@@ -50,7 +50,8 @@ public:
     enum EventListRoles {
         EventObjectRole = Qt::UserRole,
         OccurrenceObjectRole,
-        IdentifierRole
+        IdentifierRole,
+        LastRole // Used by classes inheriting CalendarEventListModel
     };
     Q_ENUM(EventListRoles)
 
@@ -67,7 +68,7 @@ public:
     bool loading() const;
 
     int rowCount(const QModelIndex &index) const;
-    QVariant data(const QModelIndex &index, int role) const;
+    virtual QVariant data(const QModelIndex &index, int role) const;
 
     virtual void classBegin();
     virtual void componentComplete();

--- a/src/calendareventlistmodel.h
+++ b/src/calendareventlistmodel.h
@@ -34,6 +34,7 @@
 
 #include <QAbstractListModel>
 #include <QQmlParserStatus>
+#include <QDateTime>
 
 class CalendarEventOccurrence;
 
@@ -43,6 +44,7 @@ class CalendarEventListModel : public QAbstractListModel, public QQmlParserStatu
     Q_INTERFACES(QQmlParserStatus)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(QStringList identifiers READ identifiers WRITE setIdentifiers NOTIFY identifiersChanged)
+    Q_PROPERTY(QDateTime startTime READ startTime WRITE setStartTime RESET resetStartTime NOTIFY startTimeChanged)
     Q_PROPERTY(QStringList missingItems READ missingItems NOTIFY missingItemsChanged)
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
@@ -63,6 +65,10 @@ public:
     QStringList identifiers() const;
     void setIdentifiers(const QStringList &ids);
 
+    QDateTime startTime() const;
+    void setStartTime(const QDateTime &);
+    void resetStartTime();
+
     QStringList missingItems() const;
 
     bool loading() const;
@@ -77,6 +83,7 @@ signals:
     void countChanged();
     void identifiersChanged();
     void missingItemsChanged();
+    void startTimeChanged();
     virtual void loadingChanged();
 
 protected:
@@ -92,8 +99,8 @@ private:
     bool mIsComplete;
     QStringList mIdentifiers;
     QStringList mMissingItems;
+    QDateTime mStartTime;
     QList<CalendarEventOccurrence*> mEvents;
-    QStringList mEventIdentifiers; // contains a subset of mIdentifiers corresponding to events in mEvents
 };
 
 #endif // CALENDAREVENTLISTMODEL_H

--- a/src/calendareventoccurrence.cpp
+++ b/src/calendareventoccurrence.cpp
@@ -52,6 +52,11 @@ CalendarEventOccurrence::~CalendarEventOccurrence()
 {
 }
 
+bool CalendarEventOccurrence::operator<(const CalendarEventOccurrence &other)
+{
+    return (mStartTime == other.mStartTime) ? (mEndTime < other.mEndTime) : (mStartTime < other.mStartTime);
+}
+
 QDateTime CalendarEventOccurrence::startTime() const
 {
     return mStartTime;

--- a/src/calendareventoccurrence.h
+++ b/src/calendareventoccurrence.h
@@ -57,6 +57,8 @@ public:
                             QObject *parent = 0);
     ~CalendarEventOccurrence();
 
+    bool operator<(const CalendarEventOccurrence &other);
+
     QDateTime startTime() const;
     QDateTime endTime() const;
     QDateTime startTimeInTz() const;

--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -39,6 +39,7 @@
 CalendarSearchModel::CalendarSearchModel(QObject *parent)
     : CalendarEventListModel(parent)
 {
+    setStartTime(QDateTime::currentDateTimeUtc());
 }
 
 CalendarSearchModel::~CalendarSearchModel()

--- a/src/calendarsearchmodel.h
+++ b/src/calendarsearchmodel.h
@@ -42,6 +42,11 @@ class CalendarSearchModel : public CalendarEventListModel
     Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
 
 public:
+    enum SearchRoles {
+        YearRole = CalendarEventListModel::LastRole
+    };
+    Q_ENUM(SearchRoles)
+
     CalendarSearchModel(QObject *parent = 0);
     ~CalendarSearchModel();
 
@@ -55,10 +60,15 @@ public:
 
     bool loading() const;
 
+    virtual QVariant data(const QModelIndex &index, int role) const;
+
 signals:
     void searchStringChanged();
     void loadingChanged();
     void limitChanged();
+
+protected:
+    virtual QHash<int, QByteArray> roleNames() const;
 
 private:
     QString mSearchString;


### PR DESCRIPTION
A placeholder for a possible implementation of using `getNextOccurrence()` to list recurring events in the serach results. Currently unimplemented.

It initially contains the commit adding the year section.