### PR TITLE
Include dbus for timed-qt5/qmacro.h

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -4,7 +4,7 @@ PLUGIN_IMPORT_PATH = org/nemomobile/calendar
 TEMPLATE = lib
 CONFIG += qt plugin hide_symbols timed-qt5
 
-QT += qml concurrent
+QT += qml concurrent dbus
 QT -= gui
 QMAKE_CXXFLAGS += -Werror
 


### PR DESCRIPTION
Without dbus module compilation fails with following error:

```
In file included from /usr/include/timed-qt5/wall-declarations.h:32,
                 from calendarworker.h:48,
                 from calendarmanager.cpp:37:
/usr/include/timed-qt5/qmacro.h:29:10: fatal error: QDBusMetaType: No such file or directory
   29 | #include <QDBusMetaType>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
```