### PR TITLE
[nemo-qml-plugin-calendar] Only check notebook validity at calendar l…

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -233,7 +233,7 @@ void CalendarWorker::saveEvent(const CalendarData::Event &eventData, bool update
 {
     QString notebookUid = eventData.calendarUid;
 
-    if (!notebookUid.isEmpty() && !mStorage->isValidNotebook(notebookUid)) {
+    if (!notebookUid.isEmpty() && !mCalendar->hasValidNotebook(notebookUid)) {
         qWarning() << "Invalid notebook uid:" << notebookUid;
         return;
     }


### PR DESCRIPTION
…evel.

There is no need to check for runtime-ness of
the notebook here, it is done at mKCal level
when saving an incidence already.

It is harmfull to check for readonly-ness of
the notebook though, since the read-only
status is only a hint. One should be able to
save modifications in a read-only notebook
when these modifications make sense (like
setting a reminder in the birthday calendar).

It is required to check that the notebook
exists in the calendar, since this check is
not done in mKCal at DB level.