### PR TITLE
[nemo-qml-plugin-calendar] Specify the notebook when purging.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.14
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.17
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(timed-qt5)

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -130,7 +130,7 @@ void CalendarWorker::storageUpdated(mKCal::ExtendedStorage *storage,
         // if the event was stored in a local (non-synced) notebook, purge it.
         const CalendarData::Notebook &notebook = mNotebooks.value(mCalendar->notebook(event));
         if (notebook.localCalendar
-            && !storage->purgeDeletedIncidences(KCalendarCore::Incidence::List() << event)) {
+            && !storage->purgeDeletedIncidences(KCalendarCore::Incidence::List() << event, notebook.uid)) {
             qWarning() << "Failed to purge deleted event" << event->uid()
                        << "from local calendar" << mCalendar->notebook(event);
         }


### PR DESCRIPTION
Provides the notebook UID of the event to
purge. Not a necessity at the moment since
event UIDs are unique in the database, but
it will allow to raise the unicity constrain
between notebooks later on.

@pvuorela : it's a follow-up of sailfishos/mkcal#59.