### PR TITLE
[nemo-qml-plugin-calendar] Follow mKCal API change in ServiceHandler.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.17
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.19
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(timed-qt5)


### PR DESCRIPTION
Directly pass the notebook to the email service API instead of passing mCalendar and mStorage.

@pvuorela, this propages the changes introduced in sailfishos/mkcal#39. I'm not aware of any other repos using this service API. Please tell me if there are actually others that require an update.