### PR TITLE
[nemo-qml-plugin-calendar] Use instanceIdentifier as hash key to stor…

### DIFF
--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -75,7 +75,6 @@ public:
 
     // Event
     CalendarData::Event getEvent(const QString& instanceIdentifier, bool *loaded = nullptr) const;
-    CalendarData::Event getEvent(const QString& uid, const QDateTime &recurrenceId);
     CalendarData::Event dissociateSingleOccurrence(const QString &eventUid, const QDateTime &recurrenceId) const;
     bool sendResponse(const QString &uid, const QDateTime &recurrenceId, CalendarEvent::Response response);
 
@@ -125,7 +124,7 @@ private slots:
     void notebooksChangedSlot(const QList<CalendarData::Notebook> &notebooks);
     void dataLoadedSlot(const QList<CalendarData::Range> &ranges,
                         const QStringList &instanceList,
-                        const QMultiHash<QString, CalendarData::Event> &events,
+                        const QHash<QString, CalendarData::Event> &events,
                         const QHash<QString, CalendarData::EventOccurrence> &occurrences,
                         const QHash<QDate, QStringList> &dailyOccurrences,
                         bool reset);
@@ -153,12 +152,11 @@ private:
     QList<CalendarData::Range> addRanges(const QList<CalendarData::Range> &oldRanges,
                                          const QList<CalendarData::Range> &newRanges);
     void updateAgendaModel(CalendarAgendaModel *model);
-    void sendEventChangeSignals(const CalendarData::Event &newEvent);
 
     QThread mWorkerThread;
     CalendarWorker *mCalendarWorker;
-    QMultiHash<QString, CalendarData::Event> mEvents;
-    QMultiHash<QString, CalendarStoredEvent *> mEventObjects;
+    QHash<QString, CalendarData::Event> mEvents;
+    QHash<QString, CalendarStoredEvent *> mEventObjects;
     QHash<QString, CalendarData::EventOccurrence> mEventOccurrences;
     QHash<QDate, QStringList> mEventOccurrenceForDates;
     QList<CalendarAgendaModel *> mAgendaRefreshList;

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -679,7 +679,7 @@ void CalendarWorker::loadData(const QList<CalendarData::Range> &ranges,
     if (reset)
         mSentEvents.clear();
 
-    QMultiHash<QString, CalendarData::Event> events;
+    QHash<QString, CalendarData::Event> events;
     bool orphansDeleted = false;
 
     const KCalendarCore::Event::List list = mCalendar->rawEvents();
@@ -714,11 +714,7 @@ void CalendarWorker::loadData(const QList<CalendarData::Range> &ranges,
         if (!mSentEvents.contains(id)) {
             CalendarData::Event event = createEventStruct(e, notebook);
             mSentEvents.insert(id);
-            events.insert(event.uniqueId, event);
-            if (id != event.uniqueId) {
-                // Ensures that events can also be retrieved by instanceIdentifier
-                events.insert(id, event);
-            }
+            events.insert(id, event);
         }
     }
 
@@ -775,7 +771,7 @@ CalendarData::Event CalendarWorker::createEventStruct(const KCalendarCore::Event
 void CalendarWorker::search(const QString &searchString, int limit)
 {
     QStringList identifiers;
-    QMultiHash<QString, CalendarData::Event> events;
+    QHash<QString, CalendarData::Event> events;
 
     if (mStorage->search(searchString, &identifiers, limit)) {
         emit searchResults(searchString, identifiers);
@@ -790,11 +786,7 @@ void CalendarWorker::search(const QString &searchString, int limit)
                 mKCal::Notebook::Ptr notebook = mStorage->notebook(mCalendar->notebook(incidence));
                 CalendarData::Event event = createEventStruct(incidence.staticCast<KCalendarCore::Event>(), notebook);
                 mSentEvents.insert(identifiers[i]);
-                events.insert(event.uniqueId, event);
-                if (identifiers[i] != event.uniqueId) {
-                    // Ensures that events can also be retrieved by instanceIdentifier
-                    events.insert(identifiers[i], event);
-                }
+                events.insert(identifiers[i], event);
             }
         }
     }

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -106,7 +106,7 @@ signals:
 
     void dataLoaded(const QList<CalendarData::Range> &ranges,
                     const QStringList &instanceList,
-                    const QMultiHash<QString, CalendarData::Event> &events,
+                    const QHash<QString, CalendarData::Event> &events,
                     const QHash<QString, CalendarData::EventOccurrence> &occurrences,
                     const QHash<QDate, QStringList> &dailyOccurrences,
                     bool reset);


### PR DESCRIPTION
…e events in the manager.

Simplify the storage of events in the manager by using a key that can uniquely identify an event, or its
exceptions.

Changing this key to include a notebook uid information will allow to store events with the same UID between different notebooks.