### PR TITLE
[nemo-qml-plugin-calendar] Avoid using mkcal private header for no reason. JB#52853

### DIFF
--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -32,7 +32,6 @@
 #include "calendarsearchmodel.h"
 #include "calendarmanager.h"
 #include "calendareventoccurrence.h"
-#include "logging_p.h"
 
 #include <QDebug>
 


### PR DESCRIPTION
Duh, didn't see  this coming.

@Tomin1 @dcaliste 