### PR TITLE
[nemo-qml-plugin-calendar] Avoid creating a manager on delete.

### DIFF
--- a/src/calendaragendamodel.cpp
+++ b/src/calendaragendamodel.cpp
@@ -50,7 +50,10 @@ CalendarAgendaModel::CalendarAgendaModel(QObject *parent)
 
 CalendarAgendaModel::~CalendarAgendaModel()
 {
-    CalendarManager::instance()->cancelAgendaRefresh(this);
+    CalendarManager *manager = CalendarManager::instance(false);
+    if (manager) {
+        manager->cancelAgendaRefresh(this);
+    }
     qDeleteAll(mEvents);
     mEvents.clear();
 }

--- a/src/calendareventlistmodel.cpp
+++ b/src/calendareventlistmodel.cpp
@@ -49,7 +49,10 @@ CalendarEventListModel::CalendarEventListModel(QObject *parent)
 
 CalendarEventListModel::~CalendarEventListModel()
 {
-    CalendarManager::instance()->cancelEventListRefresh(this);
+    CalendarManager *manager = CalendarManager::instance(false);
+    if (manager) {
+        manager->cancelEventListRefresh(this);
+    }
     qDeleteAll(mEvents);
     mEvents.clear();
 }

--- a/src/calendareventquery.cpp
+++ b/src/calendareventquery.cpp
@@ -52,7 +52,10 @@ CalendarEventQuery::CalendarEventQuery()
 
 CalendarEventQuery::~CalendarEventQuery()
 {
-    CalendarManager::instance()->cancelEventQueryRefresh(this);
+    CalendarManager *manager = CalendarManager::instance(false);
+    if (manager) {
+        manager->cancelEventQueryRefresh(this);
+    }
 }
 
 // The uid of the matched event

--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -43,7 +43,10 @@ CalendarSearchModel::CalendarSearchModel(QObject *parent)
 
 CalendarSearchModel::~CalendarSearchModel()
 {
-    CalendarManager::instance()->cancelSearch(this);
+    CalendarManager *manager = CalendarManager::instance(false);
+    if (manager) {
+        manager->cancelSearch(this);
+    }
 }
 
 QHash<int, QByteArray> CalendarSearchModel::roleNames() const


### PR DESCRIPTION
If the model and the manager are both owned by
the QApplication, they may be deleted in a
random order on application quit. We should
then avoid to recreate a manager if this one
has been already deleted.

This situation is happening in the tests for
instance.

@pvuorela , I encountered this problem in the searchmodel test for instance. It created random segfault or a warning about QEventLoop lacking of a QApplication after the test complete.