### PR TITLE
[nemo-qmlplugin-calendar] Don't expect a calendar reset on a notebook…

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.19
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.22
 BuildRequires:  pkgconfig(KF5CalendarCore)
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(timed-qt5)

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -559,6 +559,8 @@ void CalendarWorker::setDefaultNotebook(const QString &notebookUid)
     if (!mStorage->setDefaultNotebook(mStorage->notebook(notebookUid))) {
         qWarning() << "unable to set default notebook";
     }
+
+    loadNotebooks();
 }
 
 QStringList CalendarWorker::excludedNotebooks() const

--- a/tests/tst_calendarmanager/tst_calendarmanager.cpp
+++ b/tests/tst_calendarmanager/tst_calendarmanager.cpp
@@ -9,6 +9,7 @@
 #include <KCalendarCore/CalFormat>
 
 #include "calendarmanager.h"
+#include "calendaragendamodel.h"
 #include <QSignalSpy>
 
 class tst_CalendarManager : public QObject
@@ -571,6 +572,26 @@ void tst_CalendarManager::test_notebookApi()
     QTRY_VERIFY(!notebookSpy.empty());
     QCOMPARE(mManager->defaultNotebook(), mAddedNotebooks.last()->uid());
     QCOMPARE(defaultNotebookSpy.count(), 2);
+
+    QSignalSpy dataUpdatedSpy(mManager, &CalendarManager::dataUpdated);
+    CalendarAgendaModel agenda;
+    agenda.setStartDate(QDate(2023, 6, 8));
+    mManager->scheduleAgendaRefresh(&agenda);
+    QTRY_VERIFY(!dataUpdatedSpy.isEmpty());
+    dataUpdatedSpy.clear();
+    QSignalSpy excludedNotebooksSpy(mManager, &CalendarManager::excludedNotebooksChanged);
+    mManager->excludeNotebook(mAddedNotebooks.first()->uid(), true);
+    QTRY_VERIFY(!dataUpdatedSpy.isEmpty());
+    QVERIFY(!excludedNotebooksSpy.isEmpty());
+    QCOMPARE(excludedNotebooksSpy.count(), 1);
+    QCOMPARE(mManager->excludedNotebooks(), QStringList() << mAddedNotebooks.first()->uid());
+    dataUpdatedSpy.clear();
+    excludedNotebooksSpy.clear();
+    mManager->excludeNotebook(mAddedNotebooks.first()->uid(), false);
+    QTRY_VERIFY(!dataUpdatedSpy.isEmpty());
+    QVERIFY(!excludedNotebooksSpy.isEmpty());
+    QCOMPARE(excludedNotebooksSpy.count(), 1);
+    QVERIFY(mManager->excludedNotebooks().isEmpty());
 }
 
 void tst_CalendarManager::cleanupTestCase()


### PR DESCRIPTION
… change.

mKCal is not emitting a storageModified signal
on in-process notebook changes. For a visibility
change, the excludedNotebookChanged signal is already asking for a reset. Only missing case was when
changing the default notebook. Color changes are
also handled by the existing notebooksChanged
slot in the manager.

As a follow-up of sailfishos/mkcal#64. Interestingly enough, there is almost no change to be done to handle the modification in mKCal. I've added a test for the visibility change, to ensure that it's still working.