### PR TITLE
[nemo-qml-plugin-calendar] Allow multi-notebook when importing. Contributes to JB#60800

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -1,7 +1,7 @@
 Name:       nemo-qml-plugin-calendar-qt5
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.7.0
+Version:    0.7.2
 Release:    1
 License:    BSD
 URL:        https://github.com/sailfishos/nemo-qml-plugin-calendar

--- a/src/calendarimportmodel.h
+++ b/src/calendarimportmodel.h
@@ -44,6 +44,7 @@ class CalendarImportModel : public QAbstractListModel
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged)
     Q_PROPERTY(QString icsString READ icsString WRITE setIcsString NOTIFY icsStringChanged)
+    Q_PROPERTY(QString targetNotebook READ notebookUid WRITE setNotebookUid NOTIFY notebookUidChanged)
     Q_PROPERTY(bool hasDuplicates READ hasDuplicates NOTIFY hasDuplicatesChanged)
     Q_PROPERTY(bool hasInvitations READ hasInvitations NOTIFY hasInvitationsChanged)
     Q_PROPERTY(bool error READ error NOTIFY errorChanged)
@@ -72,6 +73,9 @@ public:
     QString icsString() const;
     void setIcsString(const QString &icsData);
 
+    QString notebookUid() const;
+    void setNotebookUid(const QString &notebookUid);
+
     bool hasDuplicates() const;
 
     bool hasInvitations() const;
@@ -88,12 +92,13 @@ signals:
     void countChanged();
     void fileNameChanged();
     void icsStringChanged();
+    void notebookUidChanged();
     void hasDuplicatesChanged();
     void hasInvitationsChanged();
     bool errorChanged();
 
 public slots:
-    bool importToNotebook(const QString &notebookUid = QString(), bool discardInvitation = false) const;
+    bool save(bool discardInvitation = false) const;
 
 protected:
     virtual QHash<int, QByteArray> roleNames() const;
@@ -101,9 +106,11 @@ protected:
 private:
     bool importToMemory(const QString &fileName, const QByteArray &icsData);
     void setError(bool error);
+    void setupDuplicates();
 
     QString mFileName;
     QByteArray mIcsRawData;
+    QString mNotebookUid;
     KCalendarCore::Event::List mEventList;
     mKCal::ExtendedStorage::Ptr mStorage;
     QSet<QString> mDuplicates;

--- a/tests/tst_calendarimportmodel/tst_calendarimportmodel.cpp
+++ b/tests/tst_calendarimportmodel/tst_calendarimportmodel.cpp
@@ -62,7 +62,13 @@ void tst_CalendarImportModel::initTestCase()
 
 void tst_CalendarImportModel::testByString()
 {
+    mKCal::ExtendedCalendar::Ptr calendar(new mKCal::ExtendedCalendar(QTimeZone::systemTimeZone()));
+    mKCal::ExtendedStorage::Ptr storage = calendar->defaultStorage(calendar);
+    QVERIFY(storage);
+    QVERIFY(storage->open());
+
     CalendarImportModel *model = new CalendarImportModel;
+    model->setNotebookUid(storage->defaultNotebook()->uid());
 
     const QString icsData =
         QStringLiteral("BEGIN:VCALENDAR\n"
@@ -145,11 +151,7 @@ void tst_CalendarImportModel::testByString()
     QVERIFY(model->data(at2, int(CalendarImportModel::InvitationRole)).toBool());
 
     // Check that importation to the local calendar is working
-    mKCal::ExtendedCalendar::Ptr calendar(new mKCal::ExtendedCalendar(QTimeZone::systemTimeZone()));
-    mKCal::ExtendedStorage::Ptr storage = calendar->defaultStorage(calendar);
-    QVERIFY(storage);
-    QVERIFY(storage->open());
-    QVERIFY(model->importToNotebook(storage->defaultNotebook()->uid()));
+    QVERIFY(model->save());
 
     QVERIFY(storage->load());
     const KCalendarCore::Incidence::Ptr ev1 = calendar->incidence(QString::fromLatin1("14B902BC-8D24-4A97-8541-63DF7FD41A73"));
@@ -164,7 +166,7 @@ void tst_CalendarImportModel::testByString()
     QVERIFY(!ev2->organizer().isEmpty());
 
     // Reimport purging invitations this time
-    QVERIFY(model->importToNotebook(storage->defaultNotebook()->uid(), true));
+    QVERIFY(model->save(true));
 
     QVERIFY(storage->close());
     calendar->close();


### PR DESCRIPTION
    When two events in different notebooks can
    share the same UID, the detection of duplicates
    during the importation must be done per
    notebook and not globally when parsing the
    ICS data.

and also:

    The instanceId member of CalendarData::Event
    is used to identify the event uniquely in the
    manager. Any other usage of CalendarData::Event
    should not set this value, since the event may
    not be owned by the manager.

@pvuorela, this sadly implies to change the API of calendarimportmodel. Indeed, the duplication must be detected when selecting a destination notebook, and changing this destination should rerun the duplication check. That's why I created a new property setting the notebookuid. It's still WIP since I need to create the corresponding PR for the UI.
