### PR TITLE
[nemo-qml-plugin-email] Avoid cache issue on reimportation.

### DIFF
--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -144,7 +144,6 @@ private:
     QList<CalendarData::Range> addRanges(const QList<CalendarData::Range> &oldRanges,
                                          const QList<CalendarData::Range> &newRanges);
     void updateAgendaModel(CalendarAgendaModel *model);
-    void sendEventChangeSignals(const CalendarData::Event &newEvent);
 
     QThread mWorkerThread;
     CalendarWorker *mCalendarWorker;


### PR DESCRIPTION
Import an ICS file once and delete the entry.
On reimportation of the same ICS file, but
to a different notebook, the old notebook
is still in use.

This is a backport of the implementation done
in cfd2ffec but not assuming that the events
are stored by instanceIdentifier.

@pvuorela, in case there will be another hot fix for the 4.5.0 branch. Here is a partial backport to avoid having cache issues when importing an event to a calendar, deciding differently, delete it and reimport it to a different calendar. The idea here is the same than the one in cfd2ffec : send notification to every objects that may have changed because of data loading. Before, this action was done in a bit convoluted way by listing the old CalendarData::Event with a matching object before sending the change notifications. The problem being that mEvents holding the old CalendarData::Event structures may be flushed, while the mEventObjects is never flushed and contains their own copy of CalendarData::Event.