### PR TITLE
[nemo-qml-plugin-calendar] Refresh models even when loading in progress.

### DIFF
--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -275,8 +275,7 @@ void CalendarManager::scheduleAgendaRefresh(CalendarAgendaModel *model)
 
     mAgendaRefreshList.append(model);
 
-    if (!mLoadPending)
-        mTimer->start();
+    mTimer->start();
 }
 
 void CalendarManager::cancelEventListRefresh(CalendarEventListModel *model)
@@ -291,8 +290,7 @@ void CalendarManager::scheduleEventListRefresh(CalendarEventListModel *model)
 
     mEventListRefreshList.append(model);
 
-    if (!mLoadPending)
-        mTimer->start();
+    mTimer->start();
 }
 
 void CalendarManager::scheduleEventQueryRefresh(CalendarEventQuery *query)
@@ -302,8 +300,7 @@ void CalendarManager::scheduleEventQueryRefresh(CalendarEventQuery *query)
 
     mQueryRefreshList.append(query);
 
-    if (!mLoadPending)
-        mTimer->start();
+    mTimer->start();
 }
 
 void CalendarManager::cancelEventQueryRefresh(CalendarEventQuery *query)
@@ -479,11 +476,8 @@ void CalendarManager::doAgendaAndQueryRefresh()
         else
             missingRanges = addRanges(missingRanges, newRanges);
     }
-
     if (mResetPending) {
         missingRanges = addRanges(missingRanges, mLoadedRanges);
-        mLoadedRanges.clear();
-        mLoadedQueries.clear();
     }
 
     QStringList missingInstanceList;
@@ -520,7 +514,8 @@ void CalendarManager::doAgendaAndQueryRefresh()
         }
     }
 
-    if (!missingRanges.isEmpty() || !missingInstanceList.isEmpty()) {
+    if ((!missingRanges.isEmpty() || !missingInstanceList.isEmpty())
+        && !mLoadPending) {
         mLoadPending = true;
         QMetaObject::invokeMethod(mCalendarWorker, "loadData", Qt::QueuedConnection,
                                   Q_ARG(QList<CalendarData::Range>, missingRanges),
@@ -532,9 +527,6 @@ void CalendarManager::doAgendaAndQueryRefresh()
 
 void CalendarManager::timeout()
 {
-    if (mLoadPending)
-        return;
-
     if (!mAgendaRefreshList.isEmpty()
         || !mQueryRefreshList.isEmpty()
         || !mEventListRefreshList.isEmpty() || mResetPending)
@@ -758,6 +750,8 @@ void CalendarManager::dataLoadedSlot(const QList<CalendarData::Range> &ranges,
         mEvents.clear();
         mEventOccurrences.clear();
         mEventOccurrenceForDates.clear();
+        mLoadedRanges.clear();
+        mLoadedQueries.clear();
     }
 
     mLoadedRanges = addRanges(mLoadedRanges, ranges);


### PR DESCRIPTION
Loading in progress should not block the views from refreshing, but just block additional call to
'loadData'. When data are loaded anyway, it will
emit a 'dataLoaded' signal that will trigger a new refresh if needed.

@pvuorela, this comes from an investigation of a strange behaviour of the calendar application of Steve Everett who I privately contacted when I see his report of [calendar not being available](https://forum.sailfishos.org/t/sorry-jolla-4-6/18839/22). I'm afraid he is suffering from several bugs, but one that is striking is (quoting his own description):
> You go into a calendar (which has many entries) and nothing is displayed. It is as though the calendar is empty. You see the horizontal line at the top of the screen flashing as for a sync. When this stops flashing after a while, all the entries are displayed as they should be. Clicking on a single entry takes you into a blank screen with ‘(Unnamed)’ in the top right hand corner of the screen where the calendar entry name would normally be.

There should not be this "unnamed" event title visible. It means that the event is not available to the CalendarManager, while it was just displayed in the month view, so definitely available.

You can reproduce this behaviour by inserting a `QThread::sleep(5)` in `mKCal::SqliteStorage::Private::loadIncidences()`. This is simulating the fact that for this user, loading from the database takes 5 seconds (investigation under progress).

The issue of seeing "unnamed" is coming from CalendarManager. There, the `doAgendaAndQueryRefresh()` is called for two things:
- query the manager for events and ask for DB load if not available,
- query the manager for events and display them if they are available.

But this function is called only if the `loadData()` is not in progress, so during DB loading, even if an event is available from a previous load, the second action of `doAgendaAndQueryRefresh()`, namely serve events for display purpose, is not called. This PR should solve this by allowing `doAgendaAndQueryRefresh()` to be called every time needed and by blocking the first action if any loading is already is progress.

For reference, the complete step by step of calendar application loading is this one:
- call `doAgendaAndQueryRefresh()` for the current month range, triggering a `loadData()` call,
- get the answer in `slotDataLoaded()` and emit `dataUpdated`,
- models call `doAgendaAndQueryRefresh()` because of the signal, which results in month view being populated,
- immediately, call `doAgendaAndQueryRefresh()` again for the previous and next month to cache them for future swipe, which triggers itself a new call to `loadData`,
- the user tap on an event in the current month, triggering `doAgendaAndQueryRefresh()` for display.

Without the PR, if the DB loading is (too) long, the loading action for caching previous and next month prevents the `doAgendaAndQueryRefresh()` to run, and the event is not displayed before the loading is finished, even if not concerned by the loading and the event already exists in the manager.

With the PR, the display action of  `doAgendaAndQueryRefresh()` is performed if the event exists in the manager. If it does not, the DB fetch is dropped only when there is already a loading action in progress. If this loading action contains the missing event, the better. If not, the `slotDataLoaded()` contains a `emit dataUpdated()` call anyway that will trigger another  `doAgendaAndQueryRefresh()` which will submit a `loadData` request with the missing event.

Tests by Steve show that this PR is fixing the lag issue on event opening. Hopefully not introducing new bugs...