### PR TITLE
[nemo-qml-plugin-calendar] Use consistently m_ naming on member variables. Fixes JB#62246

### DIFF
--- a/lightweight/calendardataservice/calendardataservice.h
+++ b/lightweight/calendardataservice/calendardataservice.h
@@ -70,11 +70,11 @@ private:
 
     void initialize();
 
-    CalendarAgendaModel *mAgendaModel;
-    QTimer mKillTimer;
-    int mTransactionIdCounter;
-    QList<DataRequest> mDataRequestQueue;
-    DataRequest mCurrentDataRequest;
+    CalendarAgendaModel *m_agendaModel;
+    QTimer m_killTimer;
+    int m_transactionIdCounter;
+    QList<DataRequest> m_dataRequestQueue;
+    DataRequest m_currentDataRequest;
 };
 
 #endif // CALENDARDATASERVICE_H

--- a/lightweight/calendareventsmodel/calendareventsmodel.h
+++ b/lightweight/calendareventsmodel/calendareventsmodel.h
@@ -142,20 +142,20 @@ private:
     void restartUpdateTimer();
     void trackMkcal();
 
-    CalendarDataServiceProxy *mProxy;
-    QFileSystemWatcher *mWatcher;
-    QTimer mUpdateDelayTimer;
-    EventDataList mEventDataList;
-    QDateTime mStartDate;
-    QDateTime mEndDate;
-    QDateTime mCreationDate;
-    QDateTime mExpiryDate;
-    int mFilterMode;
-    int mContentType;
-    int mEventLimit;
-    int mTotalCount;
-    int mEventDisplayTime;
-    QString mTransactionId;
+    CalendarDataServiceProxy *m_proxy;
+    QFileSystemWatcher *m_watcher;
+    QTimer m_updateDelayTimer;
+    EventDataList m_eventDataList;
+    QDateTime m_startDate;
+    QDateTime m_endDate;
+    QDateTime m_creationDate;
+    QDateTime m_expiryDate;
+    int m_filterMode;
+    int m_contentType;
+    int m_eventLimit;
+    int m_totalCount;
+    int m_eventDisplayTime;
+    QString m_transactionId;
     bool m_mkcalTracked;
 };
 

--- a/src/calendaragendamodel.h
+++ b/src/calendaragendamodel.h
@@ -106,12 +106,12 @@ private slots:
     void onTimezoneChanged();
 
 private:
-    QDate mStartDate;
-    QDate mEndDate;
-    QList<CalendarEventOccurrence *> mEvents;
+    QDate m_startDate;
+    QDate m_endDate;
+    QList<CalendarEventOccurrence *> m_events;
 
-    bool mIsComplete;
-    int mFilterMode;
+    bool m_isComplete;
+    int m_filterMode;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(CalendarAgendaModel::FilterModes)

--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -44,17 +44,17 @@
 #include "calendardata.h"
 
 CalendarEvent::CalendarEvent(const CalendarData::Event *data, QObject *parent)
-    : QObject(parent), mData(new CalendarData::Event)
+    : QObject(parent), m_data(new CalendarData::Event)
 {
     if (data)
-        *mData = *data;
+        *m_data = *data;
 }
 
 CalendarEvent::CalendarEvent(const CalendarEvent *other, QObject *parent)
-    : QObject(parent), mData(new CalendarData::Event)
+    : QObject(parent), m_data(new CalendarData::Event)
 {
     if (other) {
-        *mData = *other->mData;
+        *m_data = *other->m_data;
     } else {
         qWarning("Null source passed to CalendarEvent().");
     }
@@ -62,17 +62,17 @@ CalendarEvent::CalendarEvent(const CalendarEvent *other, QObject *parent)
 
 CalendarEvent::~CalendarEvent()
 {
-    delete mData;
+    delete m_data;
 }
 
 QString CalendarEvent::displayLabel() const
 {
-    return mData->displayLabel;
+    return m_data->displayLabel;
 }
 
 QString CalendarEvent::description() const
 {
-    return mData->description;
+    return m_data->description;
 }
 
 QDateTime CalendarEvent::startTime() const
@@ -81,13 +81,13 @@ QDateTime CalendarEvent::startTime() const
     // will be in UTC also and the UI will convert it to local when displaying
     // the time, while in every other case, it set the QDateTime in
     // local zone.
-    const QDateTime dt = mData->startTime;
+    const QDateTime dt = m_data->startTime;
     return QDateTime(dt.date(), dt.time());
 }
 
 QDateTime CalendarEvent::endTime() const
 {
-    const QDateTime dt = mData->endTime;
+    const QDateTime dt = m_data->endTime;
     return QDateTime(dt.date(), dt.time());
 }
 
@@ -102,130 +102,130 @@ static Qt::TimeSpec toTimeSpec(const QDateTime &dt)
 
 Qt::TimeSpec CalendarEvent::startTimeSpec() const
 {
-    return toTimeSpec(mData->startTime);
+    return toTimeSpec(m_data->startTime);
 }
 
 Qt::TimeSpec CalendarEvent::endTimeSpec() const
 {
-    return toTimeSpec(mData->endTime);
+    return toTimeSpec(m_data->endTime);
 }
 
 QString CalendarEvent::startTimeZone() const
 {
-    return QString::fromLatin1(mData->startTime.timeZone().id());
+    return QString::fromLatin1(m_data->startTime.timeZone().id());
 }
 
 QString CalendarEvent::endTimeZone() const
 {
-    return QString::fromLatin1(mData->endTime.timeZone().id());
+    return QString::fromLatin1(m_data->endTime.timeZone().id());
 }
 
 bool CalendarEvent::allDay() const
 {
-    return mData->allDay;
+    return m_data->allDay;
 }
 
 CalendarEvent::Recur CalendarEvent::recur() const
 {
-    return mData->recur;
+    return m_data->recur;
 }
 
 QDateTime CalendarEvent::recurEndDate() const
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    return mData->recurEndDate.endOfDay();
+    return m_data->recurEndDate.endOfDay();
 #else
-    return QDateTime(mData->recurEndDate);
+    return QDateTime(m_data->recurEndDate);
 #endif
 }
 
 bool CalendarEvent::hasRecurEndDate() const
 {
-    return mData->recurEndDate.isValid();
+    return m_data->recurEndDate.isValid();
 }
 
 CalendarEvent::Days CalendarEvent::recurWeeklyDays() const
 {
-    return mData->recurWeeklyDays;
+    return m_data->recurWeeklyDays;
 }
 
 int CalendarEvent::reminder() const
 {
-    return mData->reminder;
+    return m_data->reminder;
 }
 
 QDateTime CalendarEvent::reminderDateTime() const
 {
-    return mData->reminderDateTime;
+    return m_data->reminderDateTime;
 }
 
 QString CalendarEvent::instanceId() const
 {
-    return mData->instanceId;
+    return m_data->instanceId;
 }
 
 bool CalendarEvent::isException() const
 {
-    return mData->recurrenceId.isValid();
+    return m_data->recurrenceId.isValid();
 }
 
 bool CalendarEvent::readOnly() const
 {
-    return mData->readOnly;
+    return m_data->readOnly;
 }
 
 QString CalendarEvent::calendarUid() const
 {
-    return mData->calendarUid;
+    return m_data->calendarUid;
 }
 
 QString CalendarEvent::location() const
 {
-    return mData->location;
+    return m_data->location;
 }
 
 CalendarEvent::Secrecy CalendarEvent::secrecy() const
 {
-    return mData->secrecy;
+    return m_data->secrecy;
 }
 
 CalendarEvent::Status CalendarEvent::status() const
 {
-    return mData->status;
+    return m_data->status;
 }
 
 CalendarEvent::SyncFailure CalendarEvent::syncFailure() const
 {
-    return mData->syncFailure;
+    return m_data->syncFailure;
 }
 
 CalendarEvent::SyncFailureResolution CalendarEvent::syncFailureResolution() const
 {
-    return mData->syncFailureResolution;
+    return m_data->syncFailureResolution;
 }
 
 CalendarEvent::Response CalendarEvent::ownerStatus() const
 {
-    return mData->ownerStatus;
+    return m_data->ownerStatus;
 }
 
 bool CalendarEvent::rsvp() const
 {
-    return mData->rsvp;
+    return m_data->rsvp;
 }
 
 bool CalendarEvent::externalInvitation() const
 {
-    return mData->externalInvitation;
+    return m_data->externalInvitation;
 }
 
 CalendarStoredEvent::CalendarStoredEvent(CalendarManager *manager, const CalendarData::Event *data)
     : CalendarEvent(data, manager)
-    , mManager(manager)
+    , m_manager(manager)
 {
-    connect(mManager, SIGNAL(notebookColorChanged(QString)),
+    connect(m_manager, SIGNAL(notebookColorChanged(QString)),
             this, SLOT(notebookColorChanged(QString)));
-    connect(mManager, &CalendarManager::instanceIdChanged,
+    connect(m_manager, &CalendarManager::instanceIdChanged,
             this, &CalendarStoredEvent::instanceIdNotified);
 }
 
@@ -235,17 +235,17 @@ CalendarStoredEvent::~CalendarStoredEvent()
 
 void CalendarStoredEvent::notebookColorChanged(QString notebookUid)
 {
-    if (mData->calendarUid == notebookUid)
+    if (m_data->calendarUid == notebookUid)
         emit colorChanged();
 }
 
 void CalendarStoredEvent::instanceIdNotified(QString oldId, QString newId, QString notebookUid)
 {
-    if (mData->instanceId == oldId) {
-        mData->instanceId = newId;
+    if (m_data->instanceId == oldId) {
+        m_data->instanceId = newId;
         emit instanceIdChanged();
         // Event uid changes when the event is moved between notebooks, calendar uid has changed
-        mData->calendarUid = notebookUid;
+        m_data->calendarUid = notebookUid;
         emit calendarUidChanged();
         emit colorChanged();
     }
@@ -253,8 +253,8 @@ void CalendarStoredEvent::instanceIdNotified(QString oldId, QString newId, QStri
 
 bool CalendarStoredEvent::sendResponse(int response)
 {
-    if (mManager->sendResponse(mData->instanceId, (Response)response)) {
-        mManager->save();
+    if (m_manager->sendResponse(m_data->instanceId, (Response)response)) {
+        m_manager->save();
         return true;
     } else {
         return false;
@@ -263,29 +263,29 @@ bool CalendarStoredEvent::sendResponse(int response)
 
 void CalendarStoredEvent::deleteEvent()
 {
-    mManager->deleteEvent(mData->instanceId, QDateTime());
-    mManager->save();
+    m_manager->deleteEvent(m_data->instanceId, QDateTime());
+    m_manager->save();
 }
 
 // Returns the event as a iCalendar string
 QString CalendarStoredEvent::iCalendar(const QString &prodId) const
 {
     Q_UNUSED(prodId);
-    if (mData->instanceId.isEmpty()) {
+    if (m_data->instanceId.isEmpty()) {
         qWarning() << "Event has no uid, returning empty iCalendar string."
                    << "Save event before calling this function";
         return QString();
     }
 
-    return mManager->convertEventToICalendarSync(mData->instanceId, prodId);
+    return m_manager->convertEventToICalendarSync(m_data->instanceId, prodId);
 }
 
 CalendarStoredEvent* CalendarStoredEvent::parent() const
 {
     if (isException()) {
         KCalendarCore::Event event;
-        event.setUid(mData->incidenceUid);
-        return mManager->eventObject(event.instanceIdentifier());
+        event.setUid(m_data->incidenceUid);
+        return m_manager->eventObject(event.instanceIdentifier());
     } else {
         return nullptr;
     }
@@ -293,7 +293,7 @@ CalendarStoredEvent* CalendarStoredEvent::parent() const
 
 QString CalendarStoredEvent::color() const
 {
-    return mManager->getNotebookColor(mData->calendarUid);
+    return m_manager->getNotebookColor(m_data->calendarUid);
 }
 
 void CalendarStoredEvent::setEvent(const CalendarData::Event *data)
@@ -301,42 +301,42 @@ void CalendarStoredEvent::setEvent(const CalendarData::Event *data)
     if (!data)
         return;
 
-    CalendarData::Event old = *mData;
-    *mData = *data;
+    CalendarData::Event old = *m_data;
+    *m_data = *data;
 
-    if (mData->allDay != old.allDay)
+    if (m_data->allDay != old.allDay)
         emit allDayChanged();
-    if (mData->displayLabel != old.displayLabel)
+    if (m_data->displayLabel != old.displayLabel)
         emit displayLabelChanged();
-    if (mData->description != old.description)
+    if (m_data->description != old.description)
         emit descriptionChanged();
-    if (mData->endTime != old.endTime)
+    if (m_data->endTime != old.endTime)
         emit endTimeChanged();
-    if (mData->location != old.location)
+    if (m_data->location != old.location)
         emit locationChanged();
-    if (mData->secrecy != old.secrecy)
+    if (m_data->secrecy != old.secrecy)
         emit secrecyChanged();
-    if (mData->status != old.status)
+    if (m_data->status != old.status)
         emit statusChanged();
-    if (mData->recur != old.recur)
+    if (m_data->recur != old.recur)
         emit recurChanged();
-    if (mData->reminder != old.reminder)
+    if (m_data->reminder != old.reminder)
         emit reminderChanged();
-    if (mData->reminderDateTime != old.reminderDateTime)
+    if (m_data->reminderDateTime != old.reminderDateTime)
         emit reminderDateTimeChanged();
-    if (mData->startTime != old.startTime)
+    if (m_data->startTime != old.startTime)
         emit startTimeChanged();
-    if (mData->rsvp != old.rsvp)
+    if (m_data->rsvp != old.rsvp)
         emit rsvpChanged();
-    if (mData->externalInvitation != old.externalInvitation)
+    if (m_data->externalInvitation != old.externalInvitation)
         emit externalInvitationChanged();
-    if (mData->ownerStatus != old.ownerStatus)
+    if (m_data->ownerStatus != old.ownerStatus)
         emit ownerStatusChanged();
-    if (mData->syncFailure != old.syncFailure)
+    if (m_data->syncFailure != old.syncFailure)
         emit syncFailureChanged();
 }
 
 CalendarData::Event CalendarStoredEvent::dissociateSingleOccurrence(const CalendarEventOccurrence *occurrence) const
 {
-    return occurrence ? mManager->dissociateSingleOccurrence(mData->instanceId, occurrence->startTime()) : CalendarData::Event();
+    return occurrence ? m_manager->dissociateSingleOccurrence(m_data->instanceId, occurrence->startTime()) : CalendarData::Event();
 }

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -197,7 +197,7 @@ signals:
     void externalInvitationChanged();
 
 protected:
-    CalendarData::Event *mData;
+    CalendarData::Event *m_data;
 };
 
 class CalendarManager;
@@ -228,7 +228,7 @@ private slots:
     void instanceIdNotified(QString oldId, QString newId, QString notebookUid);
 
 private:
-    CalendarManager *mManager;
+    CalendarManager *m_manager;
 };
 
 #endif // CALENDAREVENT_H

--- a/src/calendareventlistmodel.h
+++ b/src/calendareventlistmodel.h
@@ -96,11 +96,11 @@ private slots:
 private:
     void refresh();
 
-    bool mIsComplete;
-    QStringList mIdentifiers;
-    QStringList mMissingItems;
-    QDateTime mStartTime;
-    QList<CalendarEventOccurrence*> mEvents;
+    bool m_isComplete;
+    QStringList m_identifiers;
+    QStringList m_missingItems;
+    QDateTime m_startTime;
+    QList<CalendarEventOccurrence*> m_events;
 };
 
 #endif // CALENDAREVENTLISTMODEL_H

--- a/src/calendareventmodification.cpp
+++ b/src/calendareventmodification.cpp
@@ -59,7 +59,7 @@ CalendarEventModification::CalendarEventModification(const CalendarStoredEvent *
     : CalendarEvent(source, parent)
 {
     if (source && occurrence)
-        *mData = source->dissociateSingleOccurrence(occurrence);
+        *m_data = source->dissociateSingleOccurrence(occurrence);
 }
 
 CalendarEventModification::CalendarEventModification(QObject *parent)
@@ -73,26 +73,26 @@ CalendarEventModification::~CalendarEventModification()
 
 QDateTime CalendarEventModification::startTime() const
 {
-    return mData->startTime;
+    return m_data->startTime;
 }
 
 QDateTime CalendarEventModification::endTime() const
 {
-    return mData->endTime;
+    return m_data->endTime;
 }
 
 void CalendarEventModification::setDisplayLabel(const QString &displayLabel)
 {
-    if (mData->displayLabel != displayLabel) {
-        mData->displayLabel = displayLabel;
+    if (m_data->displayLabel != displayLabel) {
+        m_data->displayLabel = displayLabel;
         emit displayLabelChanged();
     }
 }
 
 void CalendarEventModification::setDescription(const QString &description)
 {
-    if (mData->description != description) {
-        mData->description = description;
+    if (m_data->description != description) {
+        m_data->description = description;
         emit descriptionChanged();
     }
 }
@@ -101,11 +101,11 @@ void CalendarEventModification::setStartTime(const QDateTime &startTime, Qt::Tim
 {
     QDateTime newStartTimeInTz = startTime;
     updateTime(&newStartTimeInTz, spec, timezone);
-    if (mData->startTime != newStartTimeInTz
-        || mData->startTime.timeSpec() != newStartTimeInTz.timeSpec()
-        || (mData->startTime.timeSpec() == Qt::TimeZone
-            && mData->startTime.timeZone() != newStartTimeInTz.timeZone())) {
-        mData->startTime = newStartTimeInTz;
+    if (m_data->startTime != newStartTimeInTz
+        || m_data->startTime.timeSpec() != newStartTimeInTz.timeSpec()
+        || (m_data->startTime.timeSpec() == Qt::TimeZone
+            && m_data->startTime.timeZone() != newStartTimeInTz.timeZone())) {
+        m_data->startTime = newStartTimeInTz;
         emit startTimeChanged();
     }
 }
@@ -114,38 +114,38 @@ void CalendarEventModification::setEndTime(const QDateTime &endTime, Qt::TimeSpe
 {
     QDateTime newEndTimeInTz = endTime;
     updateTime(&newEndTimeInTz, spec, timezone);
-    if (mData->endTime != newEndTimeInTz
-        || mData->endTime.timeSpec() != newEndTimeInTz.timeSpec()
-        || (mData->endTime.timeSpec() == Qt::TimeZone
-            && mData->endTime.timeZone() != newEndTimeInTz.timeZone())) {
-        mData->endTime = newEndTimeInTz;
+    if (m_data->endTime != newEndTimeInTz
+        || m_data->endTime.timeSpec() != newEndTimeInTz.timeSpec()
+        || (m_data->endTime.timeSpec() == Qt::TimeZone
+            && m_data->endTime.timeZone() != newEndTimeInTz.timeZone())) {
+        m_data->endTime = newEndTimeInTz;
         emit endTimeChanged();
     }
 }
 
 void CalendarEventModification::setAllDay(bool allDay)
 {
-    if (mData->allDay != allDay) {
-        mData->allDay = allDay;
+    if (m_data->allDay != allDay) {
+        m_data->allDay = allDay;
         emit allDayChanged();
     }
 }
 
 void CalendarEventModification::setRecur(CalendarEvent::Recur recur)
 {
-    if (mData->recur != recur) {
-        mData->recur = recur;
+    if (m_data->recur != recur) {
+        m_data->recur = recur;
         emit recurChanged();
     }
 }
 
 void CalendarEventModification::setRecurEndDate(const QDateTime &dateTime)
 {
-    bool wasValid = mData->recurEndDate.isValid();
+    bool wasValid = m_data->recurEndDate.isValid();
     QDate date = dateTime.date();
 
-    if (mData->recurEndDate != date) {
-        mData->recurEndDate = date;
+    if (m_data->recurEndDate != date) {
+        m_data->recurEndDate = date;
         emit recurEndDateChanged();
 
         if (date.isValid() != wasValid) {
@@ -161,40 +161,40 @@ void CalendarEventModification::unsetRecurEndDate()
 
 void CalendarEventModification::setRecurWeeklyDays(CalendarEvent::Days days)
 {
-    if (mData->recurWeeklyDays != days) {
-        mData->recurWeeklyDays = days;
+    if (m_data->recurWeeklyDays != days) {
+        m_data->recurWeeklyDays = days;
         emit recurWeeklyDaysChanged();
     }
 }
 
 void CalendarEventModification::setReminder(int seconds)
 {
-    if (seconds != mData->reminder) {
-        mData->reminder = seconds;
+    if (seconds != m_data->reminder) {
+        m_data->reminder = seconds;
         emit reminderChanged();
     }
 }
 
 void CalendarEventModification::setReminderDateTime(const QDateTime &dateTime)
 {
-    if (dateTime != mData->reminderDateTime) {
-        mData->reminderDateTime = dateTime;
+    if (dateTime != m_data->reminderDateTime) {
+        m_data->reminderDateTime = dateTime;
         emit reminderDateTimeChanged();
     }
 }
 
 void CalendarEventModification::setLocation(const QString &newLocation)
 {
-    if (newLocation != mData->location) {
-        mData->location = newLocation;
+    if (newLocation != m_data->location) {
+        m_data->location = newLocation;
         emit locationChanged();
     }
 }
 
 void CalendarEventModification::setCalendarUid(const QString &uid)
 {
-    if (mData->calendarUid != uid) {
-        mData->calendarUid = uid;
+    if (m_data->calendarUid != uid) {
+        m_data->calendarUid = uid;
         emit calendarUidChanged();
     }
 }
@@ -213,14 +213,14 @@ void CalendarEventModification::setAttendees(CalendarContactModel *required, Cal
 
 void CalendarEventModification::save()
 {
-    CalendarManager::instance()->saveModification(*mData, m_attendeesSet,
+    CalendarManager::instance()->saveModification(*m_data, m_attendeesSet,
                                                   m_requiredAttendees, m_optionalAttendees);
 }
 
 void CalendarEventModification::setSyncFailureResolution(CalendarEvent::SyncFailureResolution resolution)
 {
-    if (mData->syncFailureResolution != resolution) {
-        mData->syncFailureResolution = resolution;
+    if (m_data->syncFailureResolution != resolution) {
+        m_data->syncFailureResolution = resolution;
         emit syncFailureResolutionChanged();
     }
 }

--- a/src/calendareventoccurrence.cpp
+++ b/src/calendareventoccurrence.cpp
@@ -45,9 +45,9 @@ CalendarEventOccurrence::CalendarEventOccurrence(QObject *parent)
 CalendarEventOccurrence::CalendarEventOccurrence(const CalendarData::EventOccurrence &occurrence,
                                                  QObject *parent)
     : QObject(parent)
-    , mInstanceId(occurrence.instanceId)
-    , mStartTime(occurrence.startTime)
-    , mEndTime(occurrence.endTime)
+    , m_instanceId(occurrence.instanceId)
+    , m_startTime(occurrence.startTime)
+    , m_endTime(occurrence.endTime)
 {
     connect(CalendarManager::instance(), &CalendarManager::instanceIdChanged,
             this, &CalendarEventOccurrence::instanceIdChanged);
@@ -59,30 +59,30 @@ CalendarEventOccurrence::~CalendarEventOccurrence()
 
 bool CalendarEventOccurrence::operator<(const CalendarEventOccurrence &other)
 {
-    return (mStartTime == other.mStartTime) ? (mEndTime < other.mEndTime) : (mStartTime < other.mStartTime);
+    return (m_startTime == other.m_startTime) ? (m_endTime < other.m_endTime) : (m_startTime < other.m_startTime);
 }
 
 QDateTime CalendarEventOccurrence::startTime() const
 {
-    return mStartTime;
+    return m_startTime;
 }
 
 QDateTime CalendarEventOccurrence::endTime() const
 {
-    return mEndTime;
+    return m_endTime;
 }
 
 CalendarStoredEvent *CalendarEventOccurrence::eventObject() const
 {
-    return CalendarManager::instance()->eventObject(mInstanceId);
+    return CalendarManager::instance()->eventObject(m_instanceId);
 }
 
 void CalendarEventOccurrence::instanceIdChanged(QString oldId, QString newId, QString notebookUid)
 {
     Q_UNUSED(notebookUid);
 
-    if (mInstanceId == oldId)
-        mInstanceId = newId;
+    if (m_instanceId == oldId)
+        m_instanceId = newId;
 }
 
 static QDateTime toEventDateTime(const QDateTime &dateTime,
@@ -106,11 +106,11 @@ static QDateTime toEventDateTime(const QDateTime &dateTime,
 QDateTime CalendarEventOccurrence::startTimeInTz() const
 {
     const CalendarEvent *event = eventObject();
-    return event ? toEventDateTime(mStartTime, event->startTimeSpec(), event->startTimeZone()) : mStartTime;
+    return event ? toEventDateTime(m_startTime, event->startTimeSpec(), event->startTimeZone()) : m_startTime;
 }
 
 QDateTime CalendarEventOccurrence::endTimeInTz() const
 {
     const CalendarEvent *event = eventObject();
-    return event ? toEventDateTime(mEndTime, event->endTimeSpec(), event->endTimeZone()) : mEndTime;
+    return event ? toEventDateTime(m_endTime, event->endTimeSpec(), event->endTimeZone()) : m_endTime;
 }

--- a/src/calendareventoccurrence.h
+++ b/src/calendareventoccurrence.h
@@ -73,9 +73,9 @@ private slots:
     void instanceIdChanged(QString oldId, QString newId, QString notebookUid);
 
 private:
-    QString mInstanceId;
-    QDateTime mStartTime;
-    QDateTime mEndTime;
+    QString m_instanceId;
+    QDateTime m_startTime;
+    QDateTime m_endTime;
 };
 
 #endif // CALENDAREVENTOCCURRENCE_H

--- a/src/calendareventquery.cpp
+++ b/src/calendareventquery.cpp
@@ -39,7 +39,7 @@
 #include <QDebug>
 
 CalendarEventQuery::CalendarEventQuery()
-    : mIsComplete(true), mOccurrence(0), mAttendeesCached(false), mEventError(false), mUpdateOccurrence(false)
+    : m_isComplete(true), m_occurrence(0), m_attendeesCached(false), m_eventError(false), m_updateOccurrence(false)
 {
     connect(CalendarManager::instance(), SIGNAL(dataUpdated()), this, SLOT(refresh()));
     connect(CalendarManager::instance(), SIGNAL(storageModified()), this, SLOT(refresh()));
@@ -61,23 +61,23 @@ CalendarEventQuery::~CalendarEventQuery()
 // The instanceId of the matched event
 QString CalendarEventQuery::instanceId() const
 {
-    return mInstanceId;
+    return m_instanceId;
 }
 
 void CalendarEventQuery::setInstanceId(const QString &instanceId)
 {
-    if (instanceId == mInstanceId)
+    if (instanceId == m_instanceId)
         return;
-    mInstanceId = instanceId;
+    m_instanceId = instanceId;
     emit instanceIdChanged();
 
-    if (mEvent.isValid()) {
-        mEvent = CalendarData::Event();
+    if (m_event.isValid()) {
+        m_event = CalendarData::Event();
         emit eventChanged();
     }
-    if (mOccurrence) {
-        delete mOccurrence;
-        mOccurrence = 0;
+    if (m_occurrence) {
+        delete m_occurrence;
+        m_occurrence = 0;
         emit occurrenceChanged();
     }
 
@@ -89,15 +89,15 @@ void CalendarEventQuery::setInstanceId(const QString &instanceId)
 // If there is no following occurrence, the previous occurrence is returned.
 QDateTime CalendarEventQuery::startTime() const
 {
-    return mStartTime;
+    return m_startTime;
 }
 
 void CalendarEventQuery::setStartTime(const QDateTime &t)
 {
-    if (t == mStartTime)
+    if (t == m_startTime)
         return;
-    mStartTime = t;
-    mUpdateOccurrence = true;
+    m_startTime = t;
+    m_updateOccurrence = true;
     emit startTimeChanged();
 
     refresh();
@@ -110,78 +110,78 @@ void CalendarEventQuery::resetStartTime()
 
 QObject *CalendarEventQuery::event() const
 {
-    if (mEvent.isValid() && mEvent.instanceId == mInstanceId)
-        return CalendarManager::instance()->eventObject(mInstanceId);
+    if (m_event.isValid() && m_event.instanceId == m_instanceId)
+        return CalendarManager::instance()->eventObject(m_instanceId);
     else
         return nullptr;
 }
 
 QObject *CalendarEventQuery::occurrence() const
 {
-    return mOccurrence;
+    return m_occurrence;
 }
 
 QList<QObject*> CalendarEventQuery::attendees()
 {
-    if (!mAttendeesCached) {
+    if (!m_attendeesCached) {
         bool resultValid = false;
-        mAttendees = CalendarManager::instance()->getEventAttendees(mInstanceId, &resultValid);
+        m_attendees = CalendarManager::instance()->getEventAttendees(m_instanceId, &resultValid);
         if (resultValid) {
-            mAttendeesCached = true;
+            m_attendeesCached = true;
         }
     }
 
-    return CalendarUtils::convertAttendeeList(mAttendees);
+    return CalendarUtils::convertAttendeeList(m_attendees);
 }
 
 void CalendarEventQuery::classBegin()
 {
-    mIsComplete = false;
+    m_isComplete = false;
 }
 
 void CalendarEventQuery::componentComplete()
 {
-    mIsComplete = true;
+    m_isComplete = true;
     refresh();
 }
 
 void CalendarEventQuery::doRefresh(CalendarData::Event event, bool eventError)
 {
-    // The value of mInstanceId may have changed, verify that we got what we asked for
-    if (event.isValid() && event.instanceId != mInstanceId)
+    // The value of m_instanceId may have changed, verify that we got what we asked for
+    if (event.isValid() && event.instanceId != m_instanceId)
         return;
 
-    bool updateOccurrence = mUpdateOccurrence;
+    bool updateOccurrence = m_updateOccurrence;
     bool signalEventChanged = false;
 
-    if (event.instanceId != mEvent.instanceId) {
-        mEvent = event;
+    if (event.instanceId != m_event.instanceId) {
+        m_event = event;
         signalEventChanged = true;
         updateOccurrence = true;
-    } else if (mEvent.isValid()) { // The event may have changed even if the pointer did not
-        if (mEvent.allDay != event.allDay
-                || mEvent.endTime != event.endTime
-                || mEvent.recur != event.recur
+    } else if (m_event.isValid()) { // The event may have changed even if the pointer did not
+        if (m_event.allDay != event.allDay
+                || m_event.endTime != event.endTime
+                || m_event.recur != event.recur
                 || event.recur == CalendarEvent::RecurCustom
-                || mEvent.startTime != event.startTime) {
-            mEvent = event;
+                || m_event.startTime != event.startTime) {
+            m_event = event;
             updateOccurrence = true;
         }
     }
 
     if (updateOccurrence) { // Err on the safe side: always update occurrence if it may have changed
-        delete mOccurrence;
-        mOccurrence = 0;
+        delete m_occurrence;
+        m_occurrence = 0;
 
-        if (mEvent.isValid()) {
+        if (m_event.isValid()) {
             CalendarEventOccurrence *occurrence = CalendarManager::instance()->getNextOccurrence(
-                    mInstanceId, mStartTime);
+                    m_instanceId, m_startTime);
             if (occurrence) {
-                mOccurrence = occurrence;
-                mOccurrence->setParent(this);
+                m_occurrence = occurrence;
+                m_occurrence->setParent(this);
             }
         }
-        mUpdateOccurrence = false;
+        m_updateOccurrence = false;
         emit occurrenceChanged();
     }
 
@@ -191,27 +191,27 @@ void CalendarEventQuery::doRefresh(CalendarData::Event event, bool eventError)
     // check if attendees have changed.
     bool resultValid = false;
     QList<CalendarData::Attendee> attendees = CalendarManager::instance()->getEventAttendees(
-            mInstanceId, &resultValid);
-    if (resultValid && mAttendees != attendees) {
-        mAttendees = attendees;
-        mAttendeesCached = true;
+            m_instanceId, &resultValid);
+    if (resultValid && m_attendees != attendees) {
+        m_attendees = attendees;
+        m_attendeesCached = true;
         emit attendeesChanged();
     }
 
-    if (mEventError != eventError) {
-        mEventError = eventError;
+    if (m_eventError != eventError) {
+        m_eventError = eventError;
         emit eventErrorChanged();
     }
 }
 
 bool CalendarEventQuery::eventError() const
 {
-    return mEventError;
+    return m_eventError;
 }
 
 void CalendarEventQuery::refresh()
 {
-    if (!mIsComplete || mInstanceId.isEmpty())
+    if (!m_isComplete || m_instanceId.isEmpty())
         return;
 
     CalendarManager::instance()->scheduleEventQueryRefresh(this);
@@ -219,24 +219,24 @@ void CalendarEventQuery::refresh()
 
 void CalendarEventQuery::onTimezoneChanged()
 {
-    if (mOccurrence) {
+    if (m_occurrence) {
         // Actually, the date times have not changed, but
         // their representations in local time (as used in QML)
         // have changed.
-        mOccurrence->startTimeChanged();
-        mOccurrence->endTimeChanged();
+        m_occurrence->startTimeChanged();
+        m_occurrence->endTimeChanged();
     }
 }
 
 void CalendarEventQuery::instanceIdNotified(QString oldId, QString newId, QString notebookUid)
 {
-    if (mInstanceId == oldId) {
-        mInstanceId = newId;
+    if (m_instanceId == oldId) {
+        m_instanceId = newId;
         emit instanceIdChanged();
 
-        if (mEvent.isValid()) {
-            mEvent.instanceId = newId;
-            mEvent.calendarUid = notebookUid;
+        if (m_event.isValid()) {
+            m_event.instanceId = newId;
+            m_event.calendarUid = notebookUid;
         } else {
             refresh();
         }

--- a/src/calendareventquery.h
+++ b/src/calendareventquery.h
@@ -143,15 +143,15 @@ private slots:
     void instanceIdNotified(QString oldId, QString newId, QString notebookUid);
 
 private:
-    bool mIsComplete;
-    QString mInstanceId;
-    QDateTime mStartTime;
-    CalendarData::Event mEvent;
-    CalendarEventOccurrence *mOccurrence;
-    bool mAttendeesCached;
-    bool mEventError;
-    bool mUpdateOccurrence;
-    QList<CalendarData::Attendee> mAttendees;
+    bool m_isComplete;
+    QString m_instanceId;
+    QDateTime m_startTime;
+    CalendarData::Event m_event;
+    CalendarEventOccurrence *m_occurrence;
+    bool m_attendeesCached;
+    bool m_eventError;
+    bool m_updateOccurrence;
+    QList<CalendarData::Attendee> m_attendees;
 };
 
 #endif

--- a/src/calendarimportevent.cpp
+++ b/src/calendarimportevent.cpp
@@ -37,44 +37,44 @@
 
 CalendarImportEvent::CalendarImportEvent(const KCalendarCore::Event::Ptr &event)
     : CalendarEvent((CalendarData::Event*)0, nullptr)
-    , mColor("#ffffff")
+    , m_color("#ffffff")
 {
     if (event) {
-        *mData = CalendarData::Event(*event);
-        mOrganizer = event->organizer().fullName();
-        mOrganizerEmail = event->organizer().email();
-        mAttendees = CalendarUtils::getEventAttendees(event);
-        mOccurrence = CalendarUtils::getNextOccurrence(event);
+        *m_data = CalendarData::Event(*event);
+        m_organizer = event->organizer().fullName();
+        m_organizerEmail = event->organizer().email();
+        m_attendees = CalendarUtils::getEventAttendees(event);
+        m_occurrence = CalendarUtils::getNextOccurrence(event);
     }
-    mData->readOnly = true;
+    m_data->readOnly = true;
 }
 
 QString CalendarImportEvent::color() const
 {
-    return mColor;
+    return m_color;
 }
 
 QList<QObject *> CalendarImportEvent::attendees() const
 {
-    return CalendarUtils::convertAttendeeList(mAttendees);
+    return CalendarUtils::convertAttendeeList(m_attendees);
 }
 
 QString CalendarImportEvent::organizer() const
 {
-    return mOrganizer;
+    return m_organizer;
 }
 
 QString CalendarImportEvent::organizerEmail() const
 {
-    return mOrganizerEmail;
+    return m_organizerEmail;
 }
 
 void CalendarImportEvent::setColor(const QString &color)
 {
-    if (mColor == color)
+    if (m_color == color)
         return;
 
-    mColor = color;
+    m_color = color;
     emit colorChanged();
 }
 
@@ -96,5 +96,5 @@ bool CalendarImportEvent::sendResponse(int response)
 
 QObject *CalendarImportEvent::nextOccurrence()
 {
-    return new CalendarEventOccurrence(mOccurrence);
+    return new CalendarEventOccurrence(m_occurrence);
 }

--- a/src/calendarimportevent.h
+++ b/src/calendarimportevent.h
@@ -71,10 +71,10 @@ signals:
     void colorChanged();
 
 private:
-    QString mColor;
-    QString mOrganizer;
-    QString mOrganizerEmail;
-    QList<CalendarData::Attendee> mAttendees;
-    CalendarData::EventOccurrence mOccurrence;
+    QString m_color;
+    QString m_organizer;
+    QString m_organizerEmail;
+    QList<CalendarData::Attendee> m_attendees;
+    CalendarData::EventOccurrence m_occurrence;
 };
 #endif // CALENDARIMPORTEVENT_H

--- a/src/calendarimportmodel.h
+++ b/src/calendarimportmodel.h
@@ -108,14 +108,14 @@ private:
     void setError(bool error);
     void setupDuplicates();
 
-    QString mFileName;
-    QByteArray mIcsRawData;
-    QString mNotebookUid;
-    KCalendarCore::Event::List mEventList;
-    mKCal::ExtendedStorage::Ptr mStorage;
-    QSet<QString> mDuplicates;
-    QSet<QString> mInvitations;
-    bool mError;
+    QString m_fileName;
+    QByteArray m_icsRawData;
+    QString m_notebookUid;
+    KCalendarCore::Event::List m_eventList;
+    mKCal::ExtendedStorage::Ptr m_storage;
+    QSet<QString> m_duplicates;
+    QSet<QString> m_invitations;
+    bool m_error;
 };
 
 #endif // CALENDARIMPORT_H

--- a/src/calendarinvitationquery.cpp
+++ b/src/calendarinvitationquery.cpp
@@ -37,8 +37,8 @@
 #include "calendarutils.h"
 
 CalendarInvitationQuery::CalendarInvitationQuery()
-    : mIsComplete(false)
-    , mNeedQuery(false)
+    : m_isComplete(false)
+    , m_needQuery(false)
 {
 }
 
@@ -52,33 +52,33 @@ CalendarInvitationQuery::~CalendarInvitationQuery()
 
 QString CalendarInvitationQuery::notebookUid() const
 {
-    return mNotebookUid;
+    return m_notebookUid;
 }
 
 QString CalendarInvitationQuery::instanceId() const
 {
-    return mInstanceId;
+    return m_instanceId;
 }
 
 QString CalendarInvitationQuery::startTime() const
 {
-    return mStartTime;
+    return m_startTime;
 }
 
 QString CalendarInvitationQuery::invitationFile() const
 {
-    return mInvitationFile;
+    return m_invitationFile;
 }
 
 bool CalendarInvitationQuery::busy() const
 {
-    return mBusy;
+    return m_busy;
 }
 
 void CalendarInvitationQuery::setInvitationFile(const QString &file)
 {
-    if (mInvitationFile != file) {
-        mInvitationFile = file;
+    if (m_invitationFile != file) {
+        m_invitationFile = file;
         emit invitationFileChanged();
     }
 
@@ -87,33 +87,33 @@ void CalendarInvitationQuery::setInvitationFile(const QString &file)
 
 void CalendarInvitationQuery::classBegin()
 {
-    mIsComplete = false;
+    m_isComplete = false;
 }
 
 void CalendarInvitationQuery::componentComplete()
 {
-    mIsComplete = true;
-    if (mNeedQuery) {
+    m_isComplete = true;
+    if (m_needQuery) {
         query();
     }
 }
 
 void CalendarInvitationQuery::query()
 {
-    if (!mInvitationFile.isEmpty()) {
-        // note: we allow scheduling the query even if mBusy is true
+    if (!m_invitationFile.isEmpty()) {
+        // note: we allow scheduling the query even if m_busy is true
         // as the client could have changed the invitation file
         // and in that case, the old query is orphaned by the manager.
-        bool oldBusy = mBusy;
-        mBusy = true;
+        bool oldBusy = m_busy;
+        m_busy = true;
         if (!oldBusy) {
             emit busyChanged();
         }
 
-        if (mIsComplete) {
-            CalendarManager::instance()->scheduleInvitationQuery(this, mInvitationFile);
+        if (m_isComplete) {
+            CalendarManager::instance()->scheduleInvitationQuery(this, m_invitationFile);
         } else {
-            mNeedQuery = true;
+            m_needQuery = true;
         }
     }
 }
@@ -124,22 +124,22 @@ void CalendarInvitationQuery::queryResult(CalendarData::Event event)
     bool needUidEmit = false;
     bool needSTEmit = false;
 
-    if (mNotebookUid != event.calendarUid) {
-        mNotebookUid = event.calendarUid;
+    if (m_notebookUid != event.calendarUid) {
+        m_notebookUid = event.calendarUid;
         needNUidEmit = true;
     }
 
-    if (mInstanceId != event.instanceId) {
-        mInstanceId = event.instanceId;
+    if (m_instanceId != event.instanceId) {
+        m_instanceId = event.instanceId;
         needUidEmit = true;
     }
 
-    if (mStartTime != event.startTime.toString(Qt::ISODate)) {
-        mStartTime = event.startTime.toString(Qt::ISODate);
+    if (m_startTime != event.startTime.toString(Qt::ISODate)) {
+        m_startTime = event.startTime.toString(Qt::ISODate);
         needSTEmit = true;
     }
 
-    mBusy = false;
+    m_busy = false;
 
     if (needNUidEmit) {
         emit notebookUidChanged();

--- a/src/calendarinvitationquery.h
+++ b/src/calendarinvitationquery.h
@@ -80,14 +80,14 @@ private:
     friend class CalendarManager;
     void queryResult(CalendarData::Event event);
 
-    bool mIsComplete;
-    bool mNeedQuery;
-    bool mBusy;
+    bool m_isComplete;
+    bool m_needQuery;
+    bool m_busy;
 
-    QString mInvitationFile;
-    QString mNotebookUid;
-    QString mInstanceId;
-    QString mStartTime;
+    QString m_invitationFile;
+    QString m_notebookUid;
+    QString m_instanceId;
+    QString m_startTime;
 };
 
 #endif

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -155,34 +155,34 @@ private:
                                          const QList<CalendarData::Range> &newRanges);
     void updateAgendaModel(CalendarAgendaModel *model);
 
-    QThread mWorkerThread;
-    CalendarWorker *mCalendarWorker;
-    QHash<QString, CalendarData::Event> mEvents;
-    QHash<QString, CalendarStoredEvent *> mEventObjects;
-    QHash<QString, CalendarData::EventOccurrence> mEventOccurrences;
-    QHash<QDate, QStringList> mEventOccurrenceForDates;
-    QList<CalendarAgendaModel *> mAgendaRefreshList;
-    QList<CalendarEventListModel *> mEventListRefreshList;
-    QList<CalendarEventQuery *> mQueryRefreshList;
-    QList<CalendarSearchModel *> mSearchList;
-    QHash<CalendarInvitationQuery *, QString> mInvitationQueryHash; // value is the invitationFile.
-    QStringList mExcludedNotebooks;
-    QHash<QString, CalendarData::Notebook> mNotebooks;
+    QThread m_workerThread;
+    CalendarWorker *m_calendarWorker;
+    QHash<QString, CalendarData::Event> m_events;
+    QHash<QString, CalendarStoredEvent *> m_eventObjects;
+    QHash<QString, CalendarData::EventOccurrence> m_eventOccurrences;
+    QHash<QDate, QStringList> m_eventOccurrenceForDates;
+    QList<CalendarAgendaModel *> m_agendaRefreshList;
+    QList<CalendarEventListModel *> m_eventListRefreshList;
+    QList<CalendarEventQuery *> m_queryRefreshList;
+    QList<CalendarSearchModel *> m_searchList;
+    QHash<CalendarInvitationQuery *, QString> m_invitationQueryHash; // value is the invitationFile.
+    QStringList m_excludedNotebooks;
+    QHash<QString, CalendarData::Notebook> m_notebooks;
 
-    QTimer *mTimer;
+    QTimer *m_timer;
 
     // If true indicates that CalendarWorker::loadRanges(...) has been called, and the response
     // has not been received in slot CalendarManager::rangesLoaded(...)
-    bool mLoadPending;
+    bool m_loadPending;
 
     // If true the next call to doAgendaRefresh() will cause a complete reload of calendar data
-    bool mResetPending;
+    bool m_resetPending;
 
     // A list of non-overlapping loaded ranges sorted by range start date
-    QList<CalendarData::Range > mLoadedRanges;
+    QList<CalendarData::Range > m_loadedRanges;
 
     // A list of event instance identifiers that have been processed by CalendarWorker
-    QStringList mLoadedQueries;
+    QStringList m_loadedQueries;
 };
 
 #endif // CALENDARMANAGER_H

--- a/src/calendarsearchmodel.cpp
+++ b/src/calendarsearchmodel.cpp
@@ -80,14 +80,14 @@ QVariant CalendarSearchModel::data(const QModelIndex &index, int role) const
 
 void CalendarSearchModel::setSearchString(const QString &searchString)
 {
-    if (searchString == mSearchString)
+    if (searchString == m_searchString)
         return;
 
-    mSearchString = searchString;
+    m_searchString = searchString;
     emit searchStringChanged();
 
     setIdentifiers(QStringList());
-    if (!mSearchString.isEmpty()) {
+    if (!m_searchString.isEmpty()) {
         CalendarManager::instance()->search(this);
         emit loadingChanged();
     }
@@ -95,23 +95,23 @@ void CalendarSearchModel::setSearchString(const QString &searchString)
 
 QString CalendarSearchModel::searchString() const
 {
-    return mSearchString;
+    return m_searchString;
 }
 
 int CalendarSearchModel::limit() const
 {
-    return mLimit;
+    return m_limit;
 }
 
 void CalendarSearchModel::setLimit(int limit)
 {
-    if (limit == mLimit)
+    if (limit == m_limit)
         return;
 
-    mLimit = limit;
+    m_limit = limit;
     emit limitChanged();
 
-    if (!mSearchString.isEmpty()) {
+    if (!m_searchString.isEmpty()) {
         CalendarManager::instance()->search(this);
         emit loadingChanged();
     }

--- a/src/calendarsearchmodel.h
+++ b/src/calendarsearchmodel.h
@@ -71,8 +71,8 @@ protected:
     virtual QHash<int, QByteArray> roleNames() const;
 
 private:
-    QString mSearchString;
-    int mLimit = 0;
+    QString m_searchString;
+    int m_limit = 0;
 };
 
 #endif

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -136,15 +136,15 @@ private:
     QHash<QDate, QStringList> dailyEventOccurrences(const QList<CalendarData::Range> &ranges,
                                                     const QList<CalendarData::EventOccurrence> &occurrences) const;
 
-    Accounts::Manager *mAccountManager;
+    Accounts::Manager *m_accountManager;
 
-    mKCal::ExtendedCalendar::Ptr mCalendar;
-    mKCal::ExtendedStorage::Ptr mStorage;
+    mKCal::ExtendedCalendar::Ptr m_calendar;
+    mKCal::ExtendedStorage::Ptr m_storage;
 
-    QHash<QString, CalendarData::Notebook> mNotebooks;
+    QHash<QString, CalendarData::Notebook> m_notebooks;
 
     // Tracks which events have been already passed to manager, using instanceIdentifiers.
-    QSet<QString> mSentEvents;
+    QSet<QString> m_sentEvents;
 };
 
 #endif // CALENDARWORKER_H

--- a/tests/tst_calendarevent/test_plugin/test_plugin.cpp
+++ b/tests/tst_calendarevent/test_plugin/test_plugin.cpp
@@ -51,7 +51,7 @@ bool TestInvitationPlugin::sendInvitation(const QString &accountId, const QStrin
     Q_UNUSED(invitation);
     Q_UNUSED(body);
 
-    mSentInvitation = invitation;
+    m_sentInvitation = invitation;
 
     return true;
 }
@@ -63,7 +63,7 @@ bool TestInvitationPlugin::sendUpdate(const QString &accountId, const KCalendarC
     Q_UNUSED(invitation);
     Q_UNUSED(body);
 
-    mUpdatedInvitations << invitation;
+    m_updatedInvitations << invitation;
 
     return true;
 }
@@ -161,10 +161,10 @@ ServiceInterface::ErrorCode TestInvitationPlugin::error() const
 
 KCalendarCore::Incidence::Ptr TestInvitationPlugin::sentInvitation() const
 {
-    return mSentInvitation;
+    return m_sentInvitation;
 }
 
 KCalendarCore::Incidence::List TestInvitationPlugin::updatedInvitations() const
 {
-    return mUpdatedInvitations;
+    return m_updatedInvitations;
 }

--- a/tests/tst_calendarevent/test_plugin/test_plugin.h
+++ b/tests/tst_calendarevent/test_plugin/test_plugin.h
@@ -90,8 +90,8 @@ public:
     //! \reimp_end
 
 private:
-    KCalendarCore::Incidence::Ptr mSentInvitation;
-    KCalendarCore::Incidence::List mUpdatedInvitations;
+    KCalendarCore::Incidence::Ptr m_sentInvitation;
+    KCalendarCore::Incidence::List m_updatedInvitations;
 };
 
 #endif

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -74,7 +74,7 @@ private:
     bool saveEvent(CalendarEventModification *eventMod, QString *uid);
     QQmlEngine *engine;
     CalendarApi *calendarApi;
-    QSet<QString> mSavedEvents;
+    QSet<QString> m_savedEvents;
 };
 
 void tst_CalendarEvent::initTestCase()
@@ -229,7 +229,7 @@ void tst_CalendarEvent::testSave()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
 
     CalendarEventQuery query;
     QSignalSpy eventSpy(&query, &CalendarEventQuery::eventChanged);
@@ -266,7 +266,7 @@ void tst_CalendarEvent::testSave()
     eventB->deleteEvent();
     QVERIFY(eventSpy.wait());
     QVERIFY(!query.event());
-    mSavedEvents.remove(uid);
+    m_savedEvents.remove(uid);
 
     delete eventMod;
 }
@@ -281,7 +281,7 @@ void tst_CalendarEvent::testModify()
     QString uid;
     QVERIFY(saveEvent(eventMod, &uid));
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
     delete eventMod;
 
     CalendarEventQuery query;
@@ -336,7 +336,7 @@ void tst_CalendarEvent::testTimeZone()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
 
     CalendarEventQuery query;
     QSignalSpy eventSpy(&query, &CalendarEventQuery::eventChanged);
@@ -361,7 +361,7 @@ void tst_CalendarEvent::testTimeZone()
     eventB->deleteEvent();
     QVERIFY(eventSpy.wait());
     QVERIFY(!query.event());
-    mSavedEvents.remove(uid);
+    m_savedEvents.remove(uid);
 
     delete eventMod;
 }
@@ -390,7 +390,7 @@ void tst_CalendarEvent::testRecurrenceException()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
 
     // need event and occurrence to replace....
     CalendarEventQuery query;
@@ -552,7 +552,7 @@ void tst_CalendarEvent::testRecurrenceException()
     calendarApi->removeAll(uid);
     QVERIFY(updated.wait());
     QVERIFY(!query.event());
-    mSavedEvents.remove(uid);
+    m_savedEvents.remove(uid);
 
     delete recurrenceException;
     delete recurrenceSecondException;
@@ -638,7 +638,7 @@ void tst_CalendarEvent::testDate()
     }
 
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
 }
 
 void tst_CalendarEvent::testRecurrence_data()
@@ -673,7 +673,7 @@ void tst_CalendarEvent::testRecurrence()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
 
     CalendarEventQuery query;
     QSignalSpy eventSpy(&query, &CalendarEventQuery::eventChanged);
@@ -688,7 +688,7 @@ void tst_CalendarEvent::testRecurrence()
     event->deleteEvent();
     QVERIFY(eventSpy.wait());
     QVERIFY(!query.event());
-    mSavedEvents.remove(uid);
+    m_savedEvents.remove(uid);
 }
 
 void tst_CalendarEvent::testRecurWeeklyDays()
@@ -712,7 +712,7 @@ void tst_CalendarEvent::testRecurWeeklyDays()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
 
     CalendarEventQuery query;
     QSignalSpy eventSpy(&query, &CalendarEventQuery::eventChanged);
@@ -728,7 +728,7 @@ void tst_CalendarEvent::testRecurWeeklyDays()
     event->deleteEvent();
     QVERIFY(eventSpy.wait());
     QVERIFY(!query.event());
-    mSavedEvents.remove(uid);
+    m_savedEvents.remove(uid);
 }
 
 void tst_CalendarEvent::testAttendees()
@@ -759,7 +759,7 @@ void tst_CalendarEvent::testAttendees()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
     delete eventMod;
 
     CalendarEventQuery query;
@@ -801,7 +801,7 @@ void tst_CalendarEvent::testAttendees()
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
-    mSavedEvents.insert(uid);
+    m_savedEvents.insert(uid);
     delete eventMod;
 
     // Check that the sendInvitation() service has received the right data.
@@ -908,9 +908,9 @@ void tst_CalendarEvent::testAttendees()
 void tst_CalendarEvent::cleanupTestCase()
 {
     QSignalSpy modified(CalendarManager::instance(), &CalendarManager::storageModified);
-    foreach (const QString &uid, mSavedEvents)
+    foreach (const QString &uid, m_savedEvents)
         calendarApi->removeAll(uid);
-    if (!mSavedEvents.isEmpty())
+    if (!m_savedEvents.isEmpty())
         QVERIFY(modified.wait());
 }
 

--- a/tests/tst_calendarmanager/tst_calendarmanager.cpp
+++ b/tests/tst_calendarmanager/tst_calendarmanager.cpp
@@ -28,17 +28,17 @@ private slots:
 private:
     mKCal::Notebook::Ptr createNotebook();
 
-    CalendarManager *mManager = nullptr;
-    mKCal::ExtendedCalendar::Ptr mCalendar;
-    mKCal::ExtendedStorage::Ptr mStorage;
-    QList<mKCal::Notebook::Ptr> mAddedNotebooks;
-    QString mDefaultNotebook;
+    CalendarManager *m_manager = nullptr;
+    mKCal::ExtendedCalendar::Ptr m_calendar;
+    mKCal::ExtendedStorage::Ptr m_storage;
+    QList<mKCal::Notebook::Ptr> m_addedNotebooks;
+    QString m_defaultNotebook;
 };
 
 void tst_CalendarManager::cleanup()
 {
-    delete mManager;
-    mManager = nullptr;
+    delete m_manager;
+    m_manager = nullptr;
 }
 
 void tst_CalendarManager::test_isRangeLoaded_data()
@@ -327,10 +327,10 @@ void tst_CalendarManager::test_isRangeLoaded()
     QFETCH(bool, loaded);
     QFETCH(QList<CalendarData::Range>, correctNewRanges);
 
-    mManager = new CalendarManager;
-    mManager->mLoadedRanges = loadedRanges;
+    m_manager = new CalendarManager;
+    m_manager->m_loadedRanges = loadedRanges;
     QList<CalendarData::Range> newRanges;
-    bool result = mManager->isRangeLoaded(testRange, &newRanges);
+    bool result = m_manager->isRangeLoaded(testRange, &newRanges);
 
     QCOMPARE(result, loaded);
     QCOMPARE(newRanges.count(), correctNewRanges.count());
@@ -509,8 +509,8 @@ void tst_CalendarManager::test_addRanges()
     QFETCH(QList<CalendarData::Range>, newRanges);
     QFETCH(QList<CalendarData::Range>, combinedRanges);
 
-    mManager = new CalendarManager;
-    QList<CalendarData::Range> result = mManager->addRanges(oldRanges, newRanges);
+    m_manager = new CalendarManager;
+    QList<CalendarData::Range> result = m_manager->addRanges(oldRanges, newRanges);
     QVERIFY(result == combinedRanges);
 }
 
@@ -529,86 +529,86 @@ mKCal::Notebook::Ptr tst_CalendarManager::createNotebook()
 
 void tst_CalendarManager::test_notebookApi()
 {
-    mManager = new CalendarManager;
-    QSignalSpy notebookSpy(mManager, SIGNAL(notebooksChanged(QList<CalendarData::Notebook>)));
+    m_manager = new CalendarManager;
+    QSignalSpy notebookSpy(m_manager, SIGNAL(notebooksChanged(QList<CalendarData::Notebook>)));
 
     // Wait for the manager to open the calendar database, etc
     QTRY_COMPARE(notebookSpy.count(), 1);
-    int notebookCount = mManager->notebooks().count();
-    mDefaultNotebook = mManager->defaultNotebook();
+    int notebookCount = m_manager->notebooks().count();
+    m_defaultNotebook = m_manager->defaultNotebook();
 
-    mCalendar = mKCal::ExtendedCalendar::Ptr(new mKCal::ExtendedCalendar(QTimeZone::systemTimeZone()));
-    mStorage = mCalendar->defaultStorage(mCalendar);
-    mStorage->open();
+    m_calendar = mKCal::ExtendedCalendar::Ptr(new mKCal::ExtendedCalendar(QTimeZone::systemTimeZone()));
+    m_storage = m_calendar->defaultStorage(m_calendar);
+    m_storage->open();
 
-    mAddedNotebooks << createNotebook();
-    QVERIFY(mStorage->addNotebook(mAddedNotebooks.last()));
-    mStorage->save();
+    m_addedNotebooks << createNotebook();
+    QVERIFY(m_storage->addNotebook(m_addedNotebooks.last()));
+    m_storage->save();
     QTRY_COMPARE(notebookSpy.count(), 2);
-    QCOMPARE(mManager->notebooks().count(), notebookCount + 1);
+    QCOMPARE(m_manager->notebooks().count(), notebookCount + 1);
 
-    mAddedNotebooks << createNotebook();
-    QVERIFY(mStorage->addNotebook(mAddedNotebooks.last()));
-    mStorage->save();
+    m_addedNotebooks << createNotebook();
+    QVERIFY(m_storage->addNotebook(m_addedNotebooks.last()));
+    m_storage->save();
     QTRY_COMPARE(notebookSpy.count(), 3);
-    QCOMPARE(mManager->notebooks().count(), notebookCount + 2);
+    QCOMPARE(m_manager->notebooks().count(), notebookCount + 2);
 
     QStringList uidList;
-    for (const CalendarData::Notebook &notebook : mManager->notebooks())
+    for (const CalendarData::Notebook &notebook : m_manager->notebooks())
         uidList << notebook.uid;
 
-    for (const mKCal::Notebook::Ptr &notebookPtr : mAddedNotebooks)
+    for (const mKCal::Notebook::Ptr &notebookPtr : m_addedNotebooks)
         QVERIFY(uidList.contains(notebookPtr->uid()));
 
-    QSignalSpy defaultNotebookSpy(mManager, SIGNAL(defaultNotebookChanged(QString)));
+    QSignalSpy defaultNotebookSpy(m_manager, SIGNAL(defaultNotebookChanged(QString)));
     notebookSpy.clear();
-    mManager->setDefaultNotebook(mAddedNotebooks.first()->uid());
+    m_manager->setDefaultNotebook(m_addedNotebooks.first()->uid());
     QTRY_VERIFY(!notebookSpy.empty());
-    QCOMPARE(mManager->defaultNotebook(), mAddedNotebooks.first()->uid());
+    QCOMPARE(m_manager->defaultNotebook(), m_addedNotebooks.first()->uid());
     QCOMPARE(defaultNotebookSpy.count(), 1);
 
     notebookSpy.clear();
-    mManager->setDefaultNotebook(mAddedNotebooks.last()->uid());
+    m_manager->setDefaultNotebook(m_addedNotebooks.last()->uid());
     QTRY_VERIFY(!notebookSpy.empty());
-    QCOMPARE(mManager->defaultNotebook(), mAddedNotebooks.last()->uid());
+    QCOMPARE(m_manager->defaultNotebook(), m_addedNotebooks.last()->uid());
     QCOMPARE(defaultNotebookSpy.count(), 2);
 
-    QSignalSpy dataUpdatedSpy(mManager, &CalendarManager::dataUpdated);
+    QSignalSpy dataUpdatedSpy(m_manager, &CalendarManager::dataUpdated);
     CalendarAgendaModel agenda;
     agenda.setStartDate(QDate(2023, 6, 8));
-    mManager->scheduleAgendaRefresh(&agenda);
+    m_manager->scheduleAgendaRefresh(&agenda);
     QTRY_VERIFY(!dataUpdatedSpy.isEmpty());
     dataUpdatedSpy.clear();
-    QSignalSpy excludedNotebooksSpy(mManager, &CalendarManager::excludedNotebooksChanged);
-    mManager->excludeNotebook(mAddedNotebooks.first()->uid(), true);
+    QSignalSpy excludedNotebooksSpy(m_manager, &CalendarManager::excludedNotebooksChanged);
+    m_manager->excludeNotebook(m_addedNotebooks.first()->uid(), true);
     QTRY_VERIFY(!dataUpdatedSpy.isEmpty());
     QVERIFY(!excludedNotebooksSpy.isEmpty());
     QCOMPARE(excludedNotebooksSpy.count(), 1);
-    QCOMPARE(mManager->excludedNotebooks(), QStringList() << mAddedNotebooks.first()->uid());
+    QCOMPARE(m_manager->excludedNotebooks(), QStringList() << m_addedNotebooks.first()->uid());
     dataUpdatedSpy.clear();
     excludedNotebooksSpy.clear();
-    mManager->excludeNotebook(mAddedNotebooks.first()->uid(), false);
+    m_manager->excludeNotebook(m_addedNotebooks.first()->uid(), false);
     QTRY_VERIFY(!dataUpdatedSpy.isEmpty());
     QVERIFY(!excludedNotebooksSpy.isEmpty());
     QCOMPARE(excludedNotebooksSpy.count(), 1);
-    QVERIFY(mManager->excludedNotebooks().isEmpty());
+    QVERIFY(m_manager->excludedNotebooks().isEmpty());
 }
 
 void tst_CalendarManager::cleanupTestCase()
 {
-    mManager = new CalendarManager;
-    mManager->setDefaultNotebook(mDefaultNotebook);
-    delete mManager;
-    mManager = nullptr;
+    m_manager = new CalendarManager;
+    m_manager->setDefaultNotebook(m_defaultNotebook);
+    delete m_manager;
+    m_manager = nullptr;
 
-    if (mStorage) {
-        for (const mKCal::Notebook::Ptr &notebookPtr : mAddedNotebooks)
-            mStorage->deleteNotebook(notebookPtr);
-        mStorage->save();
-        mStorage->close();
-        mStorage.clear();
+    if (m_storage) {
+        for (const mKCal::Notebook::Ptr &notebookPtr : m_addedNotebooks)
+            m_storage->deleteNotebook(notebookPtr);
+        m_storage->save();
+        m_storage->close();
+        m_storage.clear();
     }
-    mCalendar.clear();
+    m_calendar.clear();
 }
 
 #include "tst_calendarmanager.moc"

--- a/tests/tst_calendarsearchmodel/tst_calendarsearchmodel.cpp
+++ b/tests/tst_calendarsearchmodel/tst_calendarsearchmodel.cpp
@@ -21,7 +21,7 @@ private slots:
 private:
     QQmlEngine *engine;
     CalendarApi *calendarApi;
-    QSet<QString> mSavedEvents;
+    QSet<QString> m_savedEvents;
 };
 
 void tst_CalendarSearchModel::initTestCase()


### PR DESCRIPTION
Let's just finally make the naming consistent. m_ prefix already partly used here.

cc @dcaliste 