### PR TITLE
[nemo-qml-plugin-calendar] Use new Notebook::isEnabled() property.

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -829,28 +829,6 @@ void CalendarWorker::search(const QString &searchString, int limit)
     }
 }
 
-static bool serviceIsEnabled(Accounts::Account *account, const QString &syncProfile)
-{
-    account->selectService();
-    if (account->enabled()) {
-        for (const Accounts::Service &service : account->services()) {
-            account->selectService(service);
-            const QStringList allKeys = account->allKeys();
-            for (const QString &key : allKeys) {
-                if (key.endsWith(QLatin1String("/profile_id"))
-                    && account->valueAsString(key) == syncProfile) {
-                    bool ret = account->enabled();
-                    account->selectService();
-                    return ret;
-                }
-            }
-        }
-        account->selectService();
-        return true;
-    }
-    return false;
-}
-
 void CalendarWorker::loadNotebooks()
 {
     QStringList defaultNotebookColors = QStringList() << "#00aeef" << "red" << "blue" << "green" << "pink" << "yellow";
@@ -864,7 +842,8 @@ void CalendarWorker::loadNotebooks()
     bool changed = m_notebooks.isEmpty();
     for (int ii = 0; ii < notebooks.count(); ++ii) {
         mKCal::Notebook::Ptr mkNotebook = notebooks.at(ii);
-        if (!mkNotebook->eventsAllowed()) {
+        if (!mkNotebook->eventsAllowed()
+            || !mkNotebook->isEnabled()) {
             continue;
         }
         
@@ -916,9 +895,6 @@ void CalendarWorker::loadNotebooks()
             if (ok && accountId > 0) {
                 Accounts::Account *account = Accounts::Account::fromId(m_accountManager, accountId, this);
                 if (account) {
-                    if (!serviceIsEnabled(account, mkNotebook->syncProfile())) {
-                        continue;
-                    }
                     notebook.accountId = accountId;
                     notebook.accountIcon = m_accountManager->provider(account->providerName()).iconName();
                     if (notebook.description.isEmpty()) {


### PR DESCRIPTION
The availability of notebooks is now based on
a notebook property. This property is set by
a piece of code running in contactsd. There is
no need to check is account or service is
enabled.

@pvuorela, using the new isEnabled() notebook property, it's possible to reduce the code here, assuming that the property is properly set somewhere else. Which means, that just remain the icon and possibly the description that are fetched from the account. They are both the sole reason to keep libaccount code here. That's a bit unfortunate, but I've no idea where else to put it. I don't think that Notebook is the best place to add an icon property.