### PR TITLE
[nemo-calendar] Avoid -WError build option. JB#63621

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -6,7 +6,6 @@ CONFIG += qt plugin hide_symbols timed-qt5
 
 QT += qml concurrent
 QT -= gui
-QMAKE_CXXFLAGS += -Werror
 
 target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH
 PKGCONFIG += KF5CalendarCore libmkcal-qt5 accounts-qt5


### PR DESCRIPTION
Kf5-calendarcore has deprecated notebook api which we still use, removed in the Qt6 version. That causes build here to fail if warnings are not tolerated. Even regardless of that the Werror maybe better not used since it will lead to problems like this for other changes outside the module.

cc @dcaliste 