### PR TITLE
[nemo-qml-plugin-calendar] Apply fixed duration only for in-day events.

### DIFF
--- a/lightweight/calendareventsmodel/calendareventsmodel.cpp
+++ b/lightweight/calendareventsmodel/calendareventsmodel.cpp
@@ -304,10 +304,9 @@ void CalendarEventsModel::getEventsResult(const QString &transactionId, const Ev
         } else {
             startTime = QDateTime::fromString(e.startTime, Qt::ISODate);
 
-            if (m_eventDisplayTime > 0) {
+            endTime = QDateTime::fromString(e.endTime, Qt::ISODate);
+            if (m_eventDisplayTime > 0 && startTime.date() == endTime.date()) {
                 endTime = startTime.addSecs(m_eventDisplayTime);
-            } else {
-                endTime = QDateTime::fromString(e.endTime, Qt::ISODate);
             }
         }
 


### PR DESCRIPTION
In the calendar event model, apply the fixed duration for events that span within a day. Events spanning on several days are treated like full day events and keep their durations.

The fixed duration is used to filter out events slightly after they started. This way of filtering doesn't work well for multi-day events since they continue to happen during one or several days after their starting date.

@pvuorela, this modification requires to adjust the labelling in the CalendarWidgetDelegate object. The purpose of this PR is to address this issue on the forum : https://forum.sailfishos.org/t/multi-day-events-in-event-view-shown-on-start-date-only/23363 where multi-day events disappear from the event view after the day.