### PR TITLE
Make unit test slightly more robust / readable

### DIFF
--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -44,14 +44,16 @@
 #include "calendardata.h"
 
 CalendarEvent::CalendarEvent(const CalendarData::Event *data, QObject *parent)
-    : QObject(parent), m_data(new CalendarData::Event)
+    : QObject(parent)
+    , m_data(new CalendarData::Event)
 {
     if (data)
         *m_data = *data;
 }
 
 CalendarEvent::CalendarEvent(const CalendarEvent *other, QObject *parent)
-    : QObject(parent), m_data(new CalendarData::Event)
+    : QObject(parent)
+    , m_data(new CalendarData::Event)
 {
     if (other) {
         *m_data = *other->m_data;
@@ -338,5 +340,6 @@ void CalendarStoredEvent::setEvent(const CalendarData::Event *data)
 
 CalendarData::Event CalendarStoredEvent::dissociateSingleOccurrence(const CalendarEventOccurrence *occurrence) const
 {
-    return occurrence ? m_manager->dissociateSingleOccurrence(m_data->instanceId, occurrence->startTime()) : CalendarData::Event();
+    return occurrence ? m_manager->dissociateSingleOccurrence(m_data->instanceId, occurrence->startTime())
+                      : CalendarData::Event();
 }

--- a/src/calendareventmodification.cpp
+++ b/src/calendareventmodification.cpp
@@ -55,7 +55,9 @@ void updateTime(QDateTime *dt, Qt::TimeSpec spec, const QString &timeZone)
 
 }
 
-CalendarEventModification::CalendarEventModification(const CalendarStoredEvent *source, const CalendarEventOccurrence *occurrence, QObject *parent)
+CalendarEventModification::CalendarEventModification(const CalendarStoredEvent *source,
+                                                     const CalendarEventOccurrence *occurrence,
+                                                     QObject *parent)
     : CalendarEvent(source, parent)
 {
     if (source && occurrence)

--- a/src/calendareventmodification.h
+++ b/src/calendareventmodification.h
@@ -57,8 +57,9 @@ class CalendarEventModification : public CalendarEvent
     Q_PROPERTY(CalendarEvent::SyncFailureResolution syncFailureResolution READ syncFailureResolution WRITE setSyncFailureResolution NOTIFY syncFailureResolutionChanged)
 
 public:
-    CalendarEventModification(const CalendarStoredEvent *source, const CalendarEventOccurrence *occurrence = 0, QObject *parent = 0);
-    explicit CalendarEventModification(QObject *parent = 0);
+    CalendarEventModification(const CalendarStoredEvent *source, const CalendarEventOccurrence *occurrence = nullptr,
+                              QObject *parent = nullptr);
+    explicit CalendarEventModification(QObject *parent = nullptr);
     ~CalendarEventModification();
 
     void setDisplayLabel(const QString &displayLabel);

--- a/src/calendareventoccurrence.cpp
+++ b/src/calendareventoccurrence.cpp
@@ -59,7 +59,8 @@ CalendarEventOccurrence::~CalendarEventOccurrence()
 
 bool CalendarEventOccurrence::operator<(const CalendarEventOccurrence &other)
 {
-    return (m_startTime == other.m_startTime) ? (m_endTime < other.m_endTime) : (m_startTime < other.m_startTime);
+    return (m_startTime == other.m_startTime) ? (m_endTime < other.m_endTime)
+                                              : (m_startTime < other.m_startTime);
 }
 
 QDateTime CalendarEventOccurrence::startTime() const

--- a/src/calendareventquery.cpp
+++ b/src/calendareventquery.cpp
@@ -39,7 +39,11 @@
 #include <QDebug>
 
 CalendarEventQuery::CalendarEventQuery()
-    : m_isComplete(true), m_occurrence(0), m_attendeesCached(false), m_eventError(false), m_updateOccurrence(false)
+    : m_isComplete(true)
+    , m_occurrence(nullptr)
+    , m_attendeesCached(false)
+    , m_eventError(false)
+    , m_updateOccurrence(false)
 {
     connect(CalendarManager::instance(), SIGNAL(dataUpdated()), this, SLOT(refresh()));
     connect(CalendarManager::instance(), SIGNAL(storageModified()), this, SLOT(refresh()));
@@ -77,7 +81,7 @@ void CalendarEventQuery::setInstanceId(const QString &instanceId)
     }
     if (m_occurrence) {
         delete m_occurrence;
-        m_occurrence = 0;
+        m_occurrence = nullptr;
         emit occurrenceChanged();
     }
 
@@ -171,7 +175,7 @@ void CalendarEventQuery::doRefresh(CalendarData::Event event, bool eventError)
 
     if (updateOccurrence) { // Err on the safe side: always update occurrence if it may have changed
         delete m_occurrence;
-        m_occurrence = 0;
+        m_occurrence = nullptr;
 
         if (m_event.isValid()) {
             CalendarEventOccurrence *occurrence = CalendarManager::instance()->getNextOccurrence(

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -169,7 +169,8 @@ void CalendarManager::saveModification(CalendarData::Event eventData, bool updat
                               Q_ARG(QList<CalendarData::EmailContact>, optional));
 }
 
-CalendarData::Event CalendarManager::dissociateSingleOccurrence(const QString &instanceId, const QDateTime &datetime) const
+CalendarData::Event CalendarManager::dissociateSingleOccurrence(const QString &instanceId,
+                                                                const QDateTime &datetime) const
 {
     CalendarData::Event event;
     // Worker method is not calling any storage method that could block.

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -75,7 +75,8 @@ namespace {
 }
 
 CalendarWorker::CalendarWorker()
-    : QObject(0), m_accountManager(0)
+    : QObject(nullptr)
+    , m_accountManager(nullptr)
 {
 }
 
@@ -261,7 +262,8 @@ QString CalendarWorker::convertEventToICalendar(const QString &instanceId, const
 
     KCalendarCore::ICalFormat fmt;
     fmt.setApplication(fmt.application(),
-                       prodId.isEmpty() ? QLatin1String("-//sailfishos.org/Sailfish//NONSGML v1.0//EN") : prodId);
+                       prodId.isEmpty() ? QLatin1String("-//sailfishos.org/Sailfish//NONSGML v1.0//EN")
+                                        : prodId);
     return fmt.toICalString(event);
 }
 
@@ -297,8 +299,8 @@ void CalendarWorker::saveEvent(const CalendarData::Event &eventData, bool update
             // for new events than trying to implement some complex logic in basesailfish-eas.
             event->setUid(event->uid().toUpper());
         } else if (eventData.recurrenceId.isValid()) {
-            KCalendarCore::Event::Ptr parent =
-                m_calendar->event(eventData.incidenceUid);
+            KCalendarCore::Event::Ptr parent = m_calendar->event(eventData.incidenceUid);
+
             if (!parent) {
                 // The parent was removed while the exception was edited.
                 qWarning("Unable to create an exception without parent");
@@ -344,7 +346,8 @@ void CalendarWorker::saveEvent(const CalendarData::Event &eventData, bool update
         updateEventAttendees(event, createNew, required, optional, notebookUid);
     }
 
-    if (createNew && !m_calendar->addEvent(event, notebookUid.isEmpty() ? m_calendar->defaultNotebook() : notebookUid)) {
+    if (createNew && !m_calendar->addEvent(event, notebookUid.isEmpty() ? m_calendar->defaultNotebook()
+                                                                        : notebookUid)) {
         qWarning() << "Cannot add event" << event->uid() << ", notebookUid:" << notebookUid;
         return;
     } else if (!createNew) {
@@ -952,7 +955,8 @@ CalendarData::EventOccurrence CalendarWorker::getNextOccurrence(const QString &i
         qWarning() << "Failed to get next occurrence, event not found. UID = " << instanceId;
         return CalendarData::EventOccurrence();
     }
-    return CalendarUtils::getNextOccurrence(event, start, event->recurs() ? m_calendar->instances(event) : KCalendarCore::Incidence::List());
+    return CalendarUtils::getNextOccurrence(event, start, event->recurs() ? m_calendar->instances(event)
+                                                                          : KCalendarCore::Incidence::List());
 }
 
 QList<CalendarData::Attendee> CalendarWorker::getEventAttendees(const QString &instanceId)
@@ -977,7 +981,9 @@ void CalendarWorker::findMatchingEvent(const QString &invitationFile)
         KCalendarCore::Incidence::Ptr incidence = incidenceList.at(i);
         if (incidence->type() == KCalendarCore::IncidenceBase::TypeEvent) {
             // Search for this event in the database.
-            loadData(QList<CalendarData::Range>() << qMakePair(incidence->dtStart().date().addDays(-1), incidence->dtStart().date().addDays(1)), QStringList(), false);
+            loadData(QList<CalendarData::Range>()
+                         << qMakePair(incidence->dtStart().date().addDays(-1),
+                                      incidence->dtStart().date().addDays(1)), QStringList(), false);
             KCalendarCore::Incidence::List dbIncidences = m_calendar->incidences();
             Q_FOREACH (KCalendarCore::Incidence::Ptr dbIncidence, dbIncidences) {
                 const QString remoteUidValue(dbIncidence->nonKDECustomProperty("X-SAILFISHOS-REMOTE-UID"));
@@ -986,7 +992,8 @@ void CalendarWorker::findMatchingEvent(const QString &invitationFile)
                     if ((!incidence->hasRecurrenceId() && !dbIncidence->hasRecurrenceId())
                             || (incidence->hasRecurrenceId() && dbIncidence->hasRecurrenceId()
                                 && incidence->recurrenceId() == dbIncidence->recurrenceId())) {
-                        emit findMatchingEventFinished(invitationFile, createEventStruct(dbIncidence.staticCast<KCalendarCore::Event>()));
+                        emit findMatchingEventFinished(invitationFile,
+                                                       createEventStruct(dbIncidence.staticCast<KCalendarCore::Event>()));
                         return;
                     }
                 }

--- a/tests/tst_calendarevent/test_plugin/test_plugin.cpp
+++ b/tests/tst_calendarevent/test_plugin/test_plugin.cpp
@@ -57,7 +57,7 @@ bool TestInvitationPlugin::sendInvitation(const QString &accountId, const QStrin
 }
 
 bool TestInvitationPlugin::sendUpdate(const QString &accountId, const KCalendarCore::Incidence::Ptr &invitation,
-                                         const QString &body)
+                                      const QString &body)
 {
     Q_UNUSED(accountId);
     Q_UNUSED(invitation);
@@ -69,7 +69,7 @@ bool TestInvitationPlugin::sendUpdate(const QString &accountId, const KCalendarC
 }
 
 bool TestInvitationPlugin::sendResponse(const QString &accountId, const KCalendarCore::Incidence::Ptr &invitation,
-                                           const QString &body)
+                                        const QString &body)
 {
     Q_UNUSED(accountId);
     Q_UNUSED(invitation);
@@ -109,7 +109,7 @@ QString TestInvitationPlugin::displayName(const mKCal::Notebook::Ptr &notebook) 
 }
 
 bool TestInvitationPlugin::downloadAttachment(const mKCal::Notebook::Ptr &notebook, const QString &uri,
-                                                 const QString &path)
+                                              const QString &path)
 {
     Q_UNUSED(notebook);
     Q_UNUSED(uri);
@@ -117,8 +117,9 @@ bool TestInvitationPlugin::downloadAttachment(const mKCal::Notebook::Ptr &notebo
     return false;
 }
 
-bool TestInvitationPlugin::deleteAttachment(const mKCal::Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &incidence,
-                                               const QString &uri)
+bool TestInvitationPlugin::deleteAttachment(const mKCal::Notebook::Ptr &notebook,
+                                            const KCalendarCore::Incidence::Ptr &incidence,
+                                            const QString &uri)
 {
     Q_UNUSED(notebook);
     Q_UNUSED(incidence);

--- a/tests/tst_calendarevent/test_plugin/test_plugin.h
+++ b/tests/tst_calendarevent/test_plugin/test_plugin.h
@@ -62,31 +62,18 @@ public:
 
     //! \reimp ServiceHandler
     QString icon() const;
-
     QString uiName() const;
-
     bool multiCalendar() const;
-
     QString emailAddress(const mKCal::Notebook::Ptr &notebook);
-
     QString displayName(const mKCal::Notebook::Ptr &notebook) const;
-
     bool downloadAttachment(const mKCal::Notebook::Ptr &notebook, const QString &uri, const QString &path);
-
     bool deleteAttachment(const mKCal::Notebook::Ptr &notebook, const KCalendarCore::Incidence::Ptr &incidence, const QString &uri);
-
     bool shareNotebook(const mKCal::Notebook::Ptr &notebook, const QStringList &sharedWith);
-
     QStringList sharedWith(const mKCal::Notebook::Ptr &notebook);
-
     QString serviceName() const;
-
     QString defaultNotebook() const;
-
     bool checkProductId(const QString &prodId) const;
-
     ErrorCode error() const;
-
     //! \reimp_end
 
 private:

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -762,6 +762,20 @@ void tst_CalendarEvent::testRecurWeeklyDays()
     m_savedEvents.remove(uid);
 }
 
+// simplistic custom comparison to avoid problems like Attendee instances generating uids if nothing set
+static bool containsAttendee(const KCalendarCore::Attendee::List list, const KCalendarCore::Attendee &attendee)
+{
+    for (const KCalendarCore::Attendee &entry : list) {
+        if (entry.name() == attendee.name()
+            && entry.email() == attendee.email()
+            && entry.role() == attendee.role()
+            && entry.status() == attendee.status()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void tst_CalendarEvent::testAttendees()
 {
     // Ensure that service handler for invitation is using the test plugin.
@@ -786,12 +800,13 @@ void tst_CalendarEvent::testAttendees()
 
     QString uid;
     bool ok = saveEvent(eventMod, &uid);
+    delete eventMod;
+
     if (!ok) {
         QFAIL("Failed to fetch new event uid");
     }
     QVERIFY(!uid.isEmpty());
     m_savedEvents.insert(uid);
-    delete eventMod;
 
     CalendarEventQuery query;
     QSignalSpy eventSpy(&query, &CalendarEventQuery::attendeesChanged);
@@ -801,13 +816,13 @@ void tst_CalendarEvent::testAttendees()
     QVERIFY(query.attendees().isEmpty());
 
     // Test the case with attendees
-    TestInvitationPlugin *plugin =
-        static_cast<TestInvitationPlugin*>(mKCal::ServiceHandler::instance().service(defaultNotebook->pluginName()));
+    TestInvitationPlugin *plugin
+        = static_cast<TestInvitationPlugin*>(mKCal::ServiceHandler::instance().service(defaultNotebook->pluginName()));
     QVERIFY(plugin);
     QVERIFY(!plugin->sentInvitation());
 
     eventMod = calendarApi->createNewEvent();
-    QVERIFY(eventMod != 0);
+    QVERIFY(eventMod);
 
     eventMod->setStartTime(QDateTime::currentDateTime(), Qt::LocalTime);
     eventMod->setEndTime(eventMod->startTime().addSecs(600), Qt::LocalTime);
@@ -829,12 +844,14 @@ void tst_CalendarEvent::testAttendees()
     Person Carl(carl, carlEmail, false, Person::OptionalParticipant, Person::UnknownParticipation);
 
     ok = saveEvent(eventMod, &uid);
+    delete eventMod;
+
     if (!ok) {
         QFAIL("Failed to fetch new event uid");
     }
+
     QVERIFY(!uid.isEmpty());
     m_savedEvents.insert(uid);
-    delete eventMod;
 
     // Check that the sendInvitation() service has received the right data.
     const KCalendarCore::Incidence::Ptr sentInvitation = plugin->sentInvitation();
@@ -842,15 +859,17 @@ void tst_CalendarEvent::testAttendees()
     QCOMPARE(sentInvitation->uid(), uid);
     const KCalendarCore::Attendee::List sentAttendees = sentInvitation->attendees();
     QCOMPARE(sentAttendees.count(), 3);
+
     KCalendarCore::Attendee attAlice(alice, aliceEmail, true, KCalendarCore::Attendee::NeedsAction,
                                      KCalendarCore::Attendee::ReqParticipant);
     KCalendarCore::Attendee attBob(bob, bobEmail, true, KCalendarCore::Attendee::NeedsAction,
                                    KCalendarCore::Attendee::ReqParticipant);
     KCalendarCore::Attendee attCarl(carl, carlEmail, true, KCalendarCore::Attendee::NeedsAction,
                                     KCalendarCore::Attendee::OptParticipant);
-    QVERIFY(sentAttendees.contains(attAlice));
-    QVERIFY(sentAttendees.contains(attBob));
-    QVERIFY(sentAttendees.contains(attCarl));
+
+    QVERIFY(containsAttendee(sentAttendees, attAlice));
+    QVERIFY(containsAttendee(sentAttendees, attBob));
+    QVERIFY(containsAttendee(sentAttendees, attCarl));
 
     // Check that saved event locally is presenting the right data.
     query.setInstanceId(uid);
@@ -923,8 +942,8 @@ void tst_CalendarEvent::testAttendees()
     QCOMPARE(cancelled->status(), KCalendarCore::Incidence::StatusCanceled);
     const KCalendarCore::Attendee::List cancelledAttendees = cancelled->attendees();
     QCOMPARE(cancelledAttendees.count(), 2);
-    QVERIFY(cancelledAttendees.contains(attBob));
-    QVERIFY(cancelledAttendees.contains(attCarl));
+    QVERIFY(containsAttendee(cancelledAttendees, attBob));
+    QVERIFY(containsAttendee(cancelledAttendees, attCarl));
     // For the updated participants.
     const KCalendarCore::Incidence::Ptr updated = updatedInvitations[1];
     QVERIFY(updated);
@@ -932,19 +951,20 @@ void tst_CalendarEvent::testAttendees()
     QCOMPARE(updated->status(), KCalendarCore::Incidence::StatusNone);
     const KCalendarCore::Attendee::List updatedAttendees = updated->attendees();
     QCOMPARE(updatedAttendees.count(), 4);
-    QVERIFY(updatedAttendees.contains(attAlice));
-    QVERIFY(updatedAttendees.contains(attDude));
+    QVERIFY(containsAttendee(updatedAttendees, attAlice));
+    QVERIFY(containsAttendee(updatedAttendees, attDude));
     KCalendarCore::Attendee attEmily(emily, emilyEmail, true, KCalendarCore::Attendee::NeedsAction,
                                      KCalendarCore::Attendee::ReqParticipant);
     KCalendarCore::Attendee attFanny(fanny, fannyEmail, true, KCalendarCore::Attendee::NeedsAction,
                                      KCalendarCore::Attendee::OptParticipant);
-    QVERIFY(updatedAttendees.contains(attEmily));
-    QVERIFY(updatedAttendees.contains(attFanny));
+    QVERIFY(containsAttendee(updatedAttendees, attEmily));
+    QVERIFY(containsAttendee(updatedAttendees, attFanny));
 }
 
 void tst_CalendarEvent::cleanupTestCase()
 {
     QSignalSpy modified(CalendarManager::instance(), &CalendarManager::storageModified);
+
     foreach (const QString &uid, m_savedEvents)
         calendarApi->removeAll(uid);
     if (!m_savedEvents.isEmpty())

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -368,35 +368,38 @@ void tst_CalendarEvent::testTimeZone()
 
 void tst_CalendarEvent::testRecurrenceException()
 {
-    CalendarEventModification *event = calendarApi->createNewEvent();
-    QVERIFY(event != 0);
-
     // Define event and exception as if device is in Vietnam,
     // then test reread from French time zone.
     const QByteArray TZenv(qgetenv("TZ"));
     qputenv("TZ", "Asia/Ho_Chi_Minh");
 
     // main event
-    event->setDisplayLabel("Recurring event");
-    QDateTime startTime = QDateTime(QDate(2014, 6, 7), QTime(12, 00), QTimeZone("Asia/Ho_Chi_Minh"));
-    QDateTime endTime = startTime.addSecs(60 * 60);
-    event->setStartTime(startTime, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    event->setEndTime(endTime, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    CalendarEvent::Recur recur = CalendarEvent::RecurWeekly;
-    event->setRecur(recur);
+    QDateTime mainStartTime = QDateTime(QDate(2014, 6, 7), QTime(12, 00), QTimeZone("Asia/Ho_Chi_Minh"));
+    QDateTime mainEndTime = mainStartTime.addSecs(60 * 60);
     QString uid;
-    bool ok = saveEvent(event, &uid);
-    if (!ok) {
-        QFAIL("Failed to fetch new event uid");
+
+    {
+        CalendarEventModification *event = calendarApi->createNewEvent();
+        QVERIFY(event);
+
+        event->setDisplayLabel("Recurring event");
+        event->setStartTime(mainStartTime, Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        event->setEndTime(mainEndTime, Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        CalendarEvent::Recur recur = CalendarEvent::RecurWeekly;
+        event->setRecur(recur);
+        bool ok = saveEvent(event, &uid);
+        if (!ok) {
+            QFAIL("Failed to fetch new event uid");
+        }
+        QVERIFY(!uid.isEmpty());
+        m_savedEvents.insert(uid);
     }
-    QVERIFY(!uid.isEmpty());
-    m_savedEvents.insert(uid);
 
     // need event and occurrence to replace....
     CalendarEventQuery query;
     QSignalSpy updated(&query, &CalendarEventQuery::eventChanged);
     query.setInstanceId(uid);
-    QDateTime secondStart = startTime.addDays(7);
+    QDateTime secondStart = mainStartTime.addDays(7);
     query.setStartTime(secondStart);
     QVERIFY(updated.wait());
 
@@ -407,132 +410,158 @@ void tst_CalendarEvent::testRecurrenceException()
     QSignalSpy dataUpdated(CalendarManager::instance(), &CalendarManager::dataUpdated);
 
     // adjust second occurrence a bit
-    CalendarEventModification *recurrenceException
-        = calendarApi->createModification(savedEvent, qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
-    QVERIFY(recurrenceException);
-    QVERIFY(recurrenceException->isException());
-
+    QString exceptionInstanceId;
     QDateTime modifiedSecond = secondStart.addSecs(10 * 60); // 12:10
-    recurrenceException->setStartTime(modifiedSecond, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    recurrenceException->setEndTime(modifiedSecond.addSecs(10*60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    recurrenceException->setDisplayLabel("Modified recurring event instance");
-    recurrenceException->save();
-    QVERIFY(dataUpdated.wait());
+
+    {
+        CalendarEventModification *recurrenceException
+            = calendarApi->createModification(savedEvent, qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
+        QVERIFY(recurrenceException);
+        QVERIFY(recurrenceException->isException());
+
+        recurrenceException->setStartTime(modifiedSecond, Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        recurrenceException->setEndTime(modifiedSecond.addSecs(10 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        recurrenceException->setDisplayLabel("Modified recurring event instance");
+        recurrenceException->save();
+        QVERIFY(dataUpdated.wait());
+
+        exceptionInstanceId = recurrenceException->instanceId();
+
+        delete recurrenceException;
+    }
 
     // Delete fourth occurrence
-    const QDateTime fourth = startTime.addDays(21).toLocalTime();
+    const QDateTime fourth = mainStartTime.addDays(21).toLocalTime();
     calendarApi->remove(savedEvent->instanceId(), fourth);
     QVERIFY(dataUpdated.wait());
 
     // Create an exception on the fifth occurrence
     QSignalSpy occurrenceChanged(&query, &CalendarEventQuery::occurrenceChanged);
-    QDateTime fifthStart = startTime.addDays(28);
+    QDateTime fifthStart = mainStartTime.addDays(28);
     query.setStartTime(fifthStart);
     QVERIFY(occurrenceChanged.wait());
     savedEvent = (CalendarStoredEvent*)query.event();
     QVERIFY(query.event());
     QVERIFY(query.occurrence());
-    CalendarEventModification *recurrenceSecondException
-        = calendarApi->createModification(qobject_cast<CalendarStoredEvent*>(query.event()),
-                                          qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
-    QVERIFY(recurrenceSecondException != 0);
-    QVERIFY(recurrenceSecondException->isException());
-    recurrenceSecondException->setDisplayLabel("Modified recurring event fifth instance");
-    recurrenceSecondException->save();
-    QVERIFY(dataUpdated.wait());
+
+    QString secondInstanceId;
+
+    {
+        CalendarEventModification *recurrenceSecondException
+            = calendarApi->createModification(qobject_cast<CalendarStoredEvent*>(query.event()),
+                                              qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
+        QVERIFY(recurrenceSecondException != 0);
+        QVERIFY(recurrenceSecondException->isException());
+        recurrenceSecondException->setDisplayLabel("Modified recurring event fifth instance");
+        recurrenceSecondException->save();
+        QVERIFY(dataUpdated.wait());
+
+        secondInstanceId = recurrenceSecondException->instanceId();
+        delete recurrenceSecondException;
+    }
 
     // Test and do actions in another time zone
     qputenv("TZ", "Europe/Paris");
 
     // check the occurrences are correct
-    CalendarEventOccurrence *occurrence = CalendarManager::instance()->getNextOccurrence(uid,
-                                                                                         startTime.addDays(-1));
+    CalendarEventOccurrence *occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(-1));
     QVERIFY(occurrence);
 
     // first
-    QCOMPARE(occurrence->startTime(), startTime);
+    QCOMPARE(occurrence->startTime(), mainStartTime);
 
     // third
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(1));
     QVERIFY(occurrence);
-    QCOMPARE(occurrence->startTime(), startTime.addDays(14));
+    QCOMPARE(occurrence->startTime(), mainStartTime.addDays(14));
 
     // second is exception
-    occurrence = CalendarManager::instance()->getNextOccurrence(recurrenceException->instanceId(),
-                                                                startTime.addDays(1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(exceptionInstanceId, mainStartTime.addDays(1));
     QVERIFY(occurrence);
     QCOMPARE(occurrence->startTime(), modifiedSecond);
 
     // fourth has been deleted and fifth is an exception
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(15));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(15));
     QVERIFY(occurrence);
-    QCOMPARE(occurrence->startTime(), startTime.addDays(35));
+    QCOMPARE(occurrence->startTime(), mainStartTime.addDays(35));
 
     // update the exception time
     QSignalSpy eventChangeSpy(&query, SIGNAL(eventChanged()));
     query.resetStartTime();
-    query.setInstanceId(recurrenceException->instanceId());
+    query.setInstanceId(exceptionInstanceId);
     eventChangeSpy.wait();
     QVERIFY(eventChangeSpy.count() > 0);
     QVERIFY(query.event());
 
-    delete recurrenceException;
-
-    recurrenceException = calendarApi->createModification(static_cast<CalendarStoredEvent*>(query.event()));
-    QVERIFY(recurrenceException);
-
-    modifiedSecond = modifiedSecond.addSecs(20 * 60); // 12:30
-    recurrenceException->setStartTime(modifiedSecond, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    recurrenceException->setEndTime(modifiedSecond.addSecs(10 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
+    // Modify the first exception again
     QString modifiedLabel("Modified recurring event instance, ver 2");
-    recurrenceException->setDisplayLabel(modifiedLabel);
-    recurrenceException->save();
-    QVERIFY(dataUpdated.wait()); // allow saved data to be reloaded
+
+    {
+        CalendarEventModification * recurrenceException
+            = calendarApi->createModification(static_cast<CalendarStoredEvent*>(query.event()));
+        QVERIFY(recurrenceException);
+
+        modifiedSecond = modifiedSecond.addSecs(20 * 60); // 12:30
+        recurrenceException->setStartTime(modifiedSecond, Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        recurrenceException->setEndTime(modifiedSecond.addSecs(10 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        recurrenceException->setDisplayLabel(modifiedLabel);
+        recurrenceException->save();
+        QVERIFY(dataUpdated.wait()); // allow saved data to be reloaded
+
+        exceptionInstanceId = recurrenceException->instanceId();
+        delete recurrenceException;
+    }
 
     // check the occurrences are correct
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(-1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(-1));
 
     // first
-    QCOMPARE(occurrence->startTime(), startTime);
+    QCOMPARE(occurrence->startTime(), mainStartTime);
 
     // third
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(1));
-    QCOMPARE(occurrence->startTime(), startTime.addDays(14));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(1));
+    QCOMPARE(occurrence->startTime(), mainStartTime.addDays(14));
 
     // second is exception
-    occurrence = CalendarManager::instance()->getNextOccurrence(recurrenceException->instanceId(),
-                                                                startTime.addDays(1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(exceptionInstanceId, mainStartTime.addDays(1));
     QVERIFY(occurrence);
     QCOMPARE(occurrence->startTime(), modifiedSecond);
 
     // Delete the second exception and check that no
     // occurrence of the parent is present.
-    calendarApi->remove(recurrenceSecondException->instanceId());
+    calendarApi->remove(secondInstanceId);
     QVERIFY(dataUpdated.wait());
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(15));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(15));
     QVERIFY(occurrence);
     // Fourth (+21 days) and fifth (+28) are now deleted.
-    QCOMPARE(occurrence->startTime(), startTime.addDays(35));
+    QCOMPARE(occurrence->startTime(), mainStartTime.addDays(35));
 
     ///////
     // update the main event time within a day, exception stays intact
-    CalendarEventModification *mod = calendarApi->createModification(savedEvent);
-    QVERIFY(mod);
-    QDateTime modifiedStart = startTime.addSecs(40 * 60); // 12:40
-    mod->setStartTime(modifiedStart, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    mod->setEndTime(modifiedStart.addSecs(40 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    mod->save();
-    QVERIFY(dataUpdated.wait());
+
+    QDateTime modifiedStart = mainStartTime.addSecs(40 * 60); // 12:40
+
+    {
+        CalendarEventModification *mod = calendarApi->createModification(savedEvent);
+        QVERIFY(mod);
+        mod->setStartTime(modifiedStart, Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        mod->setEndTime(modifiedStart.addSecs(40 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
+        mod->save();
+        QVERIFY(dataUpdated.wait());
+
+        delete mod;
+    }
 
     // and check
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(-1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(-1));
     QCOMPARE(occurrence->startTime(), modifiedStart);
-    occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(uid, mainStartTime.addDays(1));
+
     // TODO: Would be the best if second occurrence in the main series stays away, but at the moment it doesn't.
     //QCOMPARE(occurrence->startTime(), modifiedStart.addDays(14));
-    occurrence = CalendarManager::instance()->getNextOccurrence(recurrenceException->instanceId(),
-                                                                startTime.addDays(1));
+    occurrence = CalendarManager::instance()->getNextOccurrence(exceptionInstanceId, mainStartTime.addDays(1));
     QVERIFY(occurrence);
+
     QCOMPARE(occurrence->startTime(), modifiedSecond);
 
     // The recurrence exception is not listed at second occurrence date anymore.
@@ -540,31 +569,25 @@ void tst_CalendarEvent::testRecurrenceException()
     // and KCalendarCore::OccurrenceIterator is not returning it.
     CalendarAgendaModel agendaModel;
     QSignalSpy populated(&agendaModel, &CalendarAgendaModel::updated);
-    agendaModel.setStartDate(startTime.addDays(7).date());
+    agendaModel.setStartDate(mainStartTime.addDays(7).date());
     agendaModel.setEndDate(agendaModel.startDate());
     QVERIFY(populated.wait());
 
-    bool modificationFound = false;
     for (int i = 0; i < agendaModel.count(); ++i) {
         QVariant eventVariant = agendaModel.get(i, CalendarAgendaModel::EventObjectRole);
         CalendarEvent *modelEvent = qvariant_cast<CalendarEvent*>(eventVariant);
         // assuming no left-over events
         if (modelEvent && modelEvent->displayLabel() == modifiedLabel) {
-            modificationFound = true;
+            QFAIL("Found modification instance which should not exist");
             break;
         }
     }
-    QVERIFY(!modificationFound);
 
     // ensure all is gone
     calendarApi->removeAll(uid);
     QVERIFY(updated.wait());
     QVERIFY(!query.event());
     m_savedEvents.remove(uid);
-
-    delete recurrenceException;
-    delete recurrenceSecondException;
-    delete mod;
 
     if (TZenv.isEmpty()) {
         qunsetenv("TZ");

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -407,10 +407,12 @@ void tst_CalendarEvent::testRecurrenceException()
     QSignalSpy dataUpdated(CalendarManager::instance(), &CalendarManager::dataUpdated);
 
     // adjust second occurrence a bit
-    CalendarEventModification *recurrenceException = calendarApi->createModification(savedEvent, qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
-    QVERIFY(recurrenceException != 0);
+    CalendarEventModification *recurrenceException
+        = calendarApi->createModification(savedEvent, qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
+    QVERIFY(recurrenceException);
     QVERIFY(recurrenceException->isException());
-    QDateTime modifiedSecond = secondStart.addSecs(10*60); // 12:10
+
+    QDateTime modifiedSecond = secondStart.addSecs(10 * 60); // 12:10
     recurrenceException->setStartTime(modifiedSecond, Qt::TimeZone, "Asia/Ho_Chi_Minh");
     recurrenceException->setEndTime(modifiedSecond.addSecs(10*60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
     recurrenceException->setDisplayLabel("Modified recurring event instance");
@@ -430,10 +432,9 @@ void tst_CalendarEvent::testRecurrenceException()
     savedEvent = (CalendarStoredEvent*)query.event();
     QVERIFY(query.event());
     QVERIFY(query.occurrence());
-    CalendarEventModification *recurrenceSecondException =
-        calendarApi->createModification
-        (qobject_cast<CalendarStoredEvent*>(query.event()),
-         qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
+    CalendarEventModification *recurrenceSecondException
+        = calendarApi->createModification(qobject_cast<CalendarStoredEvent*>(query.event()),
+                                          qobject_cast<CalendarEventOccurrence*>(query.occurrence()));
     QVERIFY(recurrenceSecondException != 0);
     QVERIFY(recurrenceSecondException->isException());
     recurrenceSecondException->setDisplayLabel("Modified recurring event fifth instance");
@@ -447,17 +448,21 @@ void tst_CalendarEvent::testRecurrenceException()
     CalendarEventOccurrence *occurrence = CalendarManager::instance()->getNextOccurrence(uid,
                                                                                          startTime.addDays(-1));
     QVERIFY(occurrence);
+
     // first
     QCOMPARE(occurrence->startTime(), startTime);
+
     // third
     occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(1));
     QVERIFY(occurrence);
     QCOMPARE(occurrence->startTime(), startTime.addDays(14));
+
     // second is exception
     occurrence = CalendarManager::instance()->getNextOccurrence(recurrenceException->instanceId(),
                                                                 startTime.addDays(1));
     QVERIFY(occurrence);
     QCOMPARE(occurrence->startTime(), modifiedSecond);
+
     // fourth has been deleted and fifth is an exception
     occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(15));
     QVERIFY(occurrence);
@@ -472,12 +477,13 @@ void tst_CalendarEvent::testRecurrenceException()
     QVERIFY(query.event());
 
     delete recurrenceException;
-    recurrenceException = calendarApi->createModification(static_cast<CalendarStoredEvent*>(query.event()));
-    QVERIFY(recurrenceException != 0);
 
-    modifiedSecond = modifiedSecond.addSecs(20*60); // 12:30
+    recurrenceException = calendarApi->createModification(static_cast<CalendarStoredEvent*>(query.event()));
+    QVERIFY(recurrenceException);
+
+    modifiedSecond = modifiedSecond.addSecs(20 * 60); // 12:30
     recurrenceException->setStartTime(modifiedSecond, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    recurrenceException->setEndTime(modifiedSecond.addSecs(10*60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
+    recurrenceException->setEndTime(modifiedSecond.addSecs(10 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
     QString modifiedLabel("Modified recurring event instance, ver 2");
     recurrenceException->setDisplayLabel(modifiedLabel);
     recurrenceException->save();
@@ -485,15 +491,17 @@ void tst_CalendarEvent::testRecurrenceException()
 
     // check the occurrences are correct
     occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(-1));
+
     // first
     QCOMPARE(occurrence->startTime(), startTime);
+
     // third
     occurrence = CalendarManager::instance()->getNextOccurrence(uid, startTime.addDays(1));
     QCOMPARE(occurrence->startTime(), startTime.addDays(14));
+
     // second is exception
     occurrence = CalendarManager::instance()->getNextOccurrence(recurrenceException->instanceId(),
                                                                 startTime.addDays(1));
-
     QVERIFY(occurrence);
     QCOMPARE(occurrence->startTime(), modifiedSecond);
 
@@ -509,10 +517,10 @@ void tst_CalendarEvent::testRecurrenceException()
     ///////
     // update the main event time within a day, exception stays intact
     CalendarEventModification *mod = calendarApi->createModification(savedEvent);
-    QVERIFY(mod != 0);
-    QDateTime modifiedStart = startTime.addSecs(40*60); // 12:40
+    QVERIFY(mod);
+    QDateTime modifiedStart = startTime.addSecs(40 * 60); // 12:40
     mod->setStartTime(modifiedStart, Qt::TimeZone, "Asia/Ho_Chi_Minh");
-    mod->setEndTime(modifiedStart.addSecs(40*60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
+    mod->setEndTime(modifiedStart.addSecs(40 * 60), Qt::TimeZone, "Asia/Ho_Chi_Minh");
     mod->save();
     QVERIFY(dataUpdated.wait());
 
@@ -770,7 +778,8 @@ void tst_CalendarEvent::testAttendees()
     QVERIFY(query.attendees().isEmpty());
 
     // Test the case with attendees
-    TestInvitationPlugin *plugin = static_cast<TestInvitationPlugin*>(mKCal::ServiceHandler::instance().service(defaultNotebook->pluginName()));
+    TestInvitationPlugin *plugin =
+        static_cast<TestInvitationPlugin*>(mKCal::ServiceHandler::instance().service(defaultNotebook->pluginName()));
     QVERIFY(plugin);
     QVERIFY(!plugin->sentInvitation());
 
@@ -810,9 +819,12 @@ void tst_CalendarEvent::testAttendees()
     QCOMPARE(sentInvitation->uid(), uid);
     const KCalendarCore::Attendee::List sentAttendees = sentInvitation->attendees();
     QCOMPARE(sentAttendees.count(), 3);
-    KCalendarCore::Attendee attAlice(alice, aliceEmail, true, KCalendarCore::Attendee::NeedsAction, KCalendarCore::Attendee::ReqParticipant);
-    KCalendarCore::Attendee attBob(bob, bobEmail, true, KCalendarCore::Attendee::NeedsAction, KCalendarCore::Attendee::ReqParticipant);
-    KCalendarCore::Attendee attCarl(carl, carlEmail, true, KCalendarCore::Attendee::NeedsAction, KCalendarCore::Attendee::OptParticipant);
+    KCalendarCore::Attendee attAlice(alice, aliceEmail, true, KCalendarCore::Attendee::NeedsAction,
+                                     KCalendarCore::Attendee::ReqParticipant);
+    KCalendarCore::Attendee attBob(bob, bobEmail, true, KCalendarCore::Attendee::NeedsAction,
+                                   KCalendarCore::Attendee::ReqParticipant);
+    KCalendarCore::Attendee attCarl(carl, carlEmail, true, KCalendarCore::Attendee::NeedsAction,
+                                    KCalendarCore::Attendee::OptParticipant);
     QVERIFY(sentAttendees.contains(attAlice));
     QVERIFY(sentAttendees.contains(attBob));
     QVERIFY(sentAttendees.contains(attCarl));
@@ -899,8 +911,10 @@ void tst_CalendarEvent::testAttendees()
     QCOMPARE(updatedAttendees.count(), 4);
     QVERIFY(updatedAttendees.contains(attAlice));
     QVERIFY(updatedAttendees.contains(attDude));
-    KCalendarCore::Attendee attEmily(emily, emilyEmail, true, KCalendarCore::Attendee::NeedsAction, KCalendarCore::Attendee::ReqParticipant);
-    KCalendarCore::Attendee attFanny(fanny, fannyEmail, true, KCalendarCore::Attendee::NeedsAction, KCalendarCore::Attendee::OptParticipant);
+    KCalendarCore::Attendee attEmily(emily, emilyEmail, true, KCalendarCore::Attendee::NeedsAction,
+                                     KCalendarCore::Attendee::ReqParticipant);
+    KCalendarCore::Attendee attFanny(fanny, fannyEmail, true, KCalendarCore::Attendee::NeedsAction,
+                                     KCalendarCore::Attendee::OptParticipant);
     QVERIFY(updatedAttendees.contains(attEmily));
     QVERIFY(updatedAttendees.contains(attFanny));
 }


### PR DESCRIPTION
Some changes while investigating the failure. Noticed there was some instability on the attendees coming from the autogenerated uid and had some trouble following the recurrence test. Recurrence is still complicated but maybe a bit better with some modifications have shorter lifetimes etc.

cc @dcaliste 